### PR TITLE
Removes language menu for ghosts.

### DIFF
--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -68,10 +68,6 @@
 	using.screen_loc = ui_ghost_pai
 	static_inventory += using
 
-	using = new /obj/screen/language_menu
-	using.icon = ui_style
-	static_inventory += using
-
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
 	..()
 	if(!mymob.client.prefs.ghost_hud)


### PR DESCRIPTION
:cl: AndrewMontagne
fix: Removed language menu for ghosts.
/:cl:

Edit by Purpose:
Fixes #26 