### PR TITLE
Upgrades wikibooks to not use iframes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -76,10 +76,11 @@
 
 	var/server
 	var/banappeals
-	var/wikiurl = "http://www.tgstation13.org/wiki" // Default wiki link.
-	var/forumurl = "http://tgstation13.org/phpBB/index.php" //default forums
-	var/rulesurl = "http://www.tgstation13.org/wiki/Rules" // default rules
-	var/githuburl = "https://www.github.com/tgstation/-tg-station" //default github
+	var/wikiurl = "https://www.oraclestation.com/wiki/Main_Page" // Default wiki link.
+	var/wikibooksurl = "http://www.oraclestation.com" // Default wiki link.
+	var/forumurl = "https://www.oraclestation.com/forum/" //default forums
+	var/rulesurl = "https://www.oraclestation.com/wiki/Rules" // default rules
+	var/githuburl = "https://github.com/OracleStation/OracleStation" //default github
 	var/githubrepoid
 
 	var/forbid_singulo_possession = 0
@@ -418,6 +419,8 @@
 					banappeals = value
 				if("wikiurl")
 					wikiurl = value
+				if("wikibooksurl")
+					wikibooksurl = value
 				if("forumurl")
 					forumurl = value
 				if("rulesurl")

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -881,31 +881,27 @@
 		initialize_wikibook()
 	..()
 
+GLOBAL_LIST_EMPTY(cached_wiki_pages)
+
 /obj/item/book/manual/wiki/proc/initialize_wikibook()
-	if(config.wikiurl)
-		dat = {"
 
-			<html><head>
-			<style>
-				iframe {
-					display: none;
-				}
-			</style>
-			</head>
-			<body>
-			<script type="text/javascript">
-				function pageloaded(myframe) {
-					document.getElementById("loading").style.display = "none";
-					myframe.style.display = "inline";
-    			}
-			</script>
-			<p id='loading'>You start skimming through the manual...</p>
-			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[config.wikiurl]/[page_link]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-			</body>
+	dat = GLOB.cached_wiki_pages[page_link]
 
-			</html>
+	if (dat)
+		return TRUE
 
-			"}
+	var/http[] = world.Export("http://www.oraclestation.com/w/index.php/[page_link]?action=render")
+
+	if(!http)
+		return FALSE
+
+	var/html = http["CONTENT"]
+	dat = file2text(html)
+	dat = replacetext(dat, "<a href=", "<a nolink=")
+	dat = replacetext(dat, "src=\"/w", "src=\"http://www.oraclestation.com/w")
+	GLOB.cached_wiki_pages[page_link] = dat
+
+	return TRUE
 
 /obj/item/book/manual/wiki/chemistry
 	name = "Chemistry Textbook"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -890,7 +890,7 @@ GLOBAL_LIST_EMPTY(cached_wiki_pages)
 	if (dat)
 		return TRUE
 
-	var/http[] = world.Export("http://www.oraclestation.com/w/index.php/[page_link]?action=render")
+	var/http[] = world.Export("[config.wikibooksurl]/w/index.php/[page_link]?action=render")
 
 	if(!http)
 		return FALSE
@@ -898,7 +898,7 @@ GLOBAL_LIST_EMPTY(cached_wiki_pages)
 	var/html = http["CONTENT"]
 	dat = file2text(html)
 	dat = replacetext(dat, "<a href=", "<a nolink=")
-	dat = replacetext(dat, "src=\"/w", "src=\"http://www.oraclestation.com/w")
+	dat = replacetext(dat, "src=\"/w", "src=\"[config.wikibooksurl]/w")
 	GLOB.cached_wiki_pages[page_link] = dat
 
 	return TRUE


### PR DESCRIPTION
The contents of manuals are now loaded from the wiki directly, instead of through an <iframe>. The requests are lazy loaded the first time the book is read and cached.

:cl: AndrewMontagne
tweak: Manuals no longer use iframes.
/:cl:
