### PR TITLE
Go-live Fixes

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -12,7 +12,7 @@
 	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	machinetype = 6
-	var/intercept = FALSE // if TRUE, broadcasts all (non-syndie) messages to syndicate channel
+	var/intercept = FALSE // if TRUE, broadcasts all syndie messages to syndicate channel
 
 /obj/machinery/telecomms/allinone/receive_signal(datum/signal/signal)
 
@@ -32,18 +32,11 @@
 		if(signal.data["slow"] > 0)
 			sleep(signal.data["slow"]) // simulate the network lag if necessary
 
-		/* ###### Broadcast a message using signal.data ###### */
-		if(!intercept)
-			Broadcast_Message(signal.data["mob"],
-							  signal.data["vmask"],
-							  signal.data["radio"], signal.data["message"],
-							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
-							  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
-							  signal.data["language"])
 
-		/* ###### Copy all non-syndie communications to the Syndicate Frequency ###### */
-		if(intercept && signal.frequency != GLOB.SYND_FREQ)
+
+
+		/* ###### Copy all syndie communications to the Syndicate Frequency ###### */
+		if(intercept && signal.frequency == GLOB.SYND_FREQ)
 			Broadcast_Message(signal.data["mob"],
 							  signal.data["vmask"],
 							  signal.data["radio"], signal.data["message"],
@@ -51,6 +44,15 @@
 							  signal.data["realname"],, signal.data["compression"], list(0, z), GLOB.SYND_FREQ, signal.data["spans"],
 							  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
 							  signal.data["language"])
+		/* ###### Broadcast a message using signal.data ###### */
+		else if(!intercept)
+			Broadcast_Message(signal.data["mob"],
+					  signal.data["vmask"],
+					  signal.data["radio"], signal.data["message"],
+					  signal.data["name"], signal.data["job"],
+					  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
+					  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
+					  signal.data["language"])
 
 /obj/machinery/telecomms/allinone/attackby(obj/item/P, mob/user, params)
 

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -33,14 +33,15 @@
 			sleep(signal.data["slow"]) // simulate the network lag if necessary
 
 		/* ###### Broadcast a message using signal.data ###### */
-		Broadcast_Message(signal.data["mob"],
-						  signal.data["vmask"],
-						  signal.data["radio"], signal.data["message"],
-						  signal.data["name"], signal.data["job"],
-						  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
-						  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
-						  signal.data["language"])
-		
+		if(!intercept)
+			Broadcast_Message(signal.data["mob"],
+							  signal.data["vmask"],
+							  signal.data["radio"], signal.data["message"],
+							  signal.data["name"], signal.data["job"],
+							  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
+							  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
+							  signal.data["language"])
+
 		/* ###### Copy all non-syndie communications to the Syndicate Frequency ###### */
 		if(intercept && signal.frequency != GLOB.SYND_FREQ)
 			Broadcast_Message(signal.data["mob"],

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -200,7 +200,6 @@
 /datum/pipeline/proc/return_air()
 	. = other_airs + air
 	if(null in .)
-		stack_trace("[src] has one or more null gas mixtures, which may cause bugs. Null mixtures will not be considered in reconcile_air().")
 		return removeNullsFromList(.)
 
 /datum/pipeline/proc/reconcile_air()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -200,6 +200,7 @@
 /datum/pipeline/proc/return_air()
 	. = other_airs + air
 	if(null in .)
+		stack_trace("[src] has one or more null gas mixtures, which may cause bugs. Null mixtures will not be considered in reconcile_air().")
 		return removeNullsFromList(.)
 
 /datum/pipeline/proc/reconcile_air()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -126,6 +126,7 @@
 	var/l_pocket = -1
 	var/back = -1
 	var/id = -1
+	var/pda_slot = -1
 	var/neck = -1
 	var/backpack_contents = -1
 	var/suit_store = -1


### PR DESCRIPTION
The pipeline warning was an extraneous warning, a proc to fix the warned issue is called right after. Fixed an oversight with the PDA slot changes. Made the duplicate radio messages go away, but no idea why /tg/ doesn't have this problem...?

:cl: AndrewMontagne
fix: Fixed PDA slot issue (#31)
fix: Fixed duplicate radio messages
/:cl:
