### PR TITLE
Omega Atmos Fixes

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2258,7 +2258,6 @@
 	req_access = null;
 	req_access_txt = "57"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -5315,9 +5314,6 @@
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -76731,9 +76727,9 @@ agF
 auQ
 avV
 awP
-bye
+bxZ
 byg
-byj
+byg
 aAD
 aBM
 ayu
@@ -76990,7 +76986,7 @@ avW
 bxZ
 axD
 byh
-byk
+byh
 aAE
 aBN
 ayv
@@ -77244,7 +77240,7 @@ asT
 atN
 auS
 avX
-bya
+bxZ
 axE
 ayw
 azA
@@ -77501,7 +77497,7 @@ asU
 atO
 arP
 apI
-byb
+bxZ
 axF
 ayx
 azB
@@ -77758,7 +77754,7 @@ asV
 atP
 auT
 avY
-byc
+bxZ
 axG
 ayy
 axG
@@ -78015,10 +78011,10 @@ asW
 atQ
 auU
 avZ
-byd
-byf
-byi
-byl
+bxZ
+bxZ
+bxZ
+bxZ
 byn
 bxK
 awQ
@@ -81138,7 +81134,7 @@ bea
 beG
 bfc
 bfH
-byu
+bys
 bgQ
 bhD
 bit
@@ -87520,7 +87516,7 @@ ape
 aqm
 abt
 abN
-atu
+acw
 abt
 aad
 aad

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -83,7 +83,8 @@
 	var/datum/gas_mixture/G = C.returnPipenetAir(src)
 	if(!G)
 		stack_trace("addMachineryMember: Null gasmix added to pipeline datum from [C] which is of type [C.type]. Nearby: ([C.x], [C.y], [C.z])")
-	other_airs |= G
+	else
+		other_airs |= G
 
 /datum/pipeline/proc/addMember(obj/machinery/atmospherics/A, obj/machinery/atmospherics/N)
 	if(istype(A, /obj/machinery/atmospherics/pipe))


### PR DESCRIPTION
Removes a bunch of duplicate pipes on Omega and stops adding null to gas mixes (but keeps error report).

No changelog as it doesn't change anything client-side.