### PR TITLE
Unbreaks lava lizurds

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -45,5 +45,5 @@
 /datum/species/unathi/ashwalker
 	name = "Ash Walker"
 	id = "ashlizard"
-	limbs_id = "lizard"
+	limbs_id = "unathi"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS,DIGITIGRADE)


### PR DESCRIPTION
They don't use the right icons for their limbs. They use none at all, as a matter of fact.

Fixes #99 