### PR TITLE
Fixes His Grace being aqquireable by surplus crate.

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1277,7 +1277,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/his_grace
 	cost = 20
 	restricted_roles = list("Chaplain")
-	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
+	surplus = 0 //Fuck no.
 
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"


### PR DESCRIPTION
Well first propsed change of mine. Found out that His Grace is surplusable and it really should be chaplin only. Fixed this quickly (and hopefully).

:cl: EldritchSigma
tweak: His Grace decided that greys with hot pink eyes are beneath his notice and decided that only holy chaplins can have him.
/ :cl:



