### PR TITLE
Goliath Tentacling Speed adjustment, they arent Japanese Manga anymore.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -37,7 +37,7 @@
 	handle_preattack()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/proc/handle_preattack()
-	if(ranged_cooldown <= world.time + ranged_cooldown_time*0.25 && !pre_attack)
+	if(ranged_cooldown <= world.time + ranged_cooldown_time*0.5 && !pre_attack)
 		pre_attack++
 	if(!pre_attack || stat || AIStatus == AI_IDLE)
 		return


### PR DESCRIPTION
Alright considering its already hard to dodge a single goliath with current movement speed try getting ganked by 3 from one of those fuckign spawners... not possible cause you cannot dodge all those tentacles. You feel like in some very weird Japanese Manga...

What I did is this handy windup it got. "Pre Attack" its called from my understanding which is when they glow red. I doubled the multiplier from 0.25 to 0.5 so you should have more time. Cause you know 5*0.25 < 5*0.5 . Hope I got this right. Now they shouldt be able to make you feel like in one of those Japanese Mangas with people dressed as schoolgirls.

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)

Fixes #113

:cl: Eldritch Sigma
Goliath are no longer behaving like they are in some Japanese Manga -> Longer Tentacle windup.
/:cl:


