### PR TITLE
Ports AI Shift-click examine from Paradise

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -131,7 +131,9 @@
 /atom/proc/AIAltClick(mob/living/silicon/ai/user)
 	AltClick(user)
 	return
-/atom/proc/AIShiftClick()
+/atom/proc/AIShiftClick(var/mob/user)
+	if(user.client)
+		user.examinate(src)
 	return
 /atom/proc/AICtrlShiftClick()
 	return


### PR DESCRIPTION
:cl: AI can Shift-click examine.
add: Ability to shift-click examine. Thanks to monster860 for the code from https://github.com/ParadiseSS13/Paradise/pull/4772
/:cl:

[why]: It seemed to be a mild annoyance that you aren't able to do this on base TG code.

Tested functionality with Cyborg shells (loading onto and off of using BORIS module), as well as exosuits. 

One difference from para that is above me to correct, however: You do not have sechud access when examining people through this method to set them to wanted. You'll still have to update records at a console for that.

Additional note: I didn't need to make the borg changes that monster did. They work a little differently and already have shift+click examine inherited from humans.