### PR TITLE
Proper Silicon Screaming

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -496,7 +496,7 @@
 			sound_to_play = H.dna.species.female_scream_sound
 		else
 			sound_to_play = H.dna.species.male_scream_sound
-	if(iscyborg(user))
+	if(issilicon(user))
 		sound_to_play = 'sound/effects/mob_effects/goonstation/robot_scream.ogg'
 
 	playsound(user.loc, sound_to_play, 50, frequency = frequency_to_use)


### PR DESCRIPTION
:cl: 
add: [SCREAMS ROBOTICALLY] (AIs use proper scream)
/:cl:

[why]:  For some strange reason, AIs screamed like people. This has been corrected.

Tested: AI, borgs

Unfortunately tg drones aren't silicons, but simple mobs, so making them do the robotic scream is beyond me.