### PR TITLE
Removes player requirement for surplus crate

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1384,7 +1384,6 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			but you never know. Contents are sorted to always be worth 50 TC."
 	item = /obj/structure/closet/crate
 	cost = 20
-	player_minimum = 20 //lowered, the times you get screwed over by this thing happens far too often
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 	cant_discount = TRUE
 


### PR DESCRIPTION
:cl: imsxz
tweak: Surplus crate can now be bought at any player count
/:cl:

I understand the logic behind locking the crate behind a player count, but part of the reason surplus crates are ordered is their potential to contain specific valuable items that may be locked behind other requirements such as needing to be a specific job.

This allows for the ability to acquire more valuable syndicate contraband that they otherwise wouldn't be able to get, by taking a risky gamble.

*It's also the only traitor item I feel comfortable buying*