### PR TITLE
Fixes the "name" taste issue

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -18,7 +18,9 @@
 	origin_tech = "biotech=1"
 
 /obj/item/reagent_containers/food/snacks/grown/New(newloc, var/obj/item/seeds/new_seed = null)
-	tastes = list(name = 1) // apples taste of apple, silly.
+	//for whatever reason BYOND will not let you just use `name` here, it has to be `src.name`
+	//don't ask why, BYOND BYOND is BYOND
+	tastes = list(src.name = 1) // apples taste of apple, silly.
 	..()
 	if(new_seed)
 		seed = new_seed.Copy()


### PR DESCRIPTION
I DON'T UNDERSTAND WHY THIS WOULD HAPPEN

I DON'T UNDERSTAND WHY IT HAPPENED

THE LAVALAND PLANTS DON'T DO ANYTHING IN A WILDLY DIFFERENT MANNER, YET THEY WERE THE ONLY CASE WHERE THIS TOOK PLACE

THE STATEMENT DIDN'T EVEN USE A STRING, BYOND HAD TO SOMEHOW TURN `name` into `"name"` HOW DID THIS HAPPEN WHY

![](https://i.imgur.com/7rHNaQn.png)

fixes #127 