### PR TITLE
Gives brain damage if you use tildes

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -80,3 +80,8 @@
 
 /mob/proc/lingcheck()
 	return 0
+
+if(findtext(message, "~"))
+	adjustBrainLoss(10) // tildes actually cause brain damage, it's a fact of nature.
+	to_chat(src, "<span class='warning'>You feel dumber for having spoken in such a mannerism.</span>")
+	var/robot = isSynthetic()


### PR DESCRIPTION
Port of paradise #4360

Excessive use of tildes gives you brain damage

:cl: AffectedArc07
add: Use of tildes (~) will apply brain damage to your character.
/:cl: