### PR TITLE
Fixes ash walker oversights

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -48,4 +48,5 @@
 	name = "Ash Walker"
 	id = "ashlizard"
 	limbs_id = "unathi"
-	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS,DIGITIGRADE)
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS,DIGITIGRADE,NO_BONES)
+	examine_text = "an Ash Walker"


### PR DESCRIPTION
:cl: imsxz
fix: Ash walkers now show the proper species on examine.
add: Ash walkers no longer have bones.
/:cl:
Fixes #159 
Fixes #162 

