### PR TITLE
Moves the clowns instrument horn to lavaland loot

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
@@ -680,6 +680,7 @@
 "bR" = (
 /obj/structure/table/glass,
 /obj/item/clothing/shoes/clown_shoes/banana_shoes,
+/obj/item/device/instrument/bikehorn,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bS" = (

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -33,7 +33,6 @@ Clown
 		/obj/item/stamp/clown = 1,
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
-		/obj/item/device/instrument/bikehorn = 1,
 		)
 
 	implants = list(/obj/item/implant/sad_trombone)


### PR DESCRIPTION
We had much adjacent debate, this was proposed and nobody disagreed at the time.

Thoughts?

:cl: Purpose
del: Clown no longer starts with his instrument horn.
add: Gilded horn added as Lavaland loot.
/ :cl: