### PR TITLE
Fixes misc omega issues

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1717,11 +1717,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Council Chamber";
-	dir = 1;
-	name = "command camera"
-	},
 /turf/open/floor/carpet,
 /area/bridge)
 "ada" = (
@@ -16081,7 +16076,7 @@
 /area/engine/atmos)
 "aAB" = (
 /obj/machinery/computer/station_alert{
-	density = 0
+	density = 1
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -28408,6 +28403,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aWp" = (
@@ -29222,6 +29221,7 @@
 	},
 /obj/item/storage/backpack/satchel/med,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/medical,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXQ" = (
@@ -29277,17 +29277,14 @@
 "aXW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/item/storage/pill_bottle/mannitol,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/wrench,
+/obj/item/storage/pill_bottle/mannitol,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXX" = (
@@ -31424,6 +31421,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bbP" = (
@@ -35059,10 +35057,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 1 North";
-	dir = 1
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 1
@@ -81915,12 +81909,12 @@ aSs
 aYc
 aYW
 byv
-byy
+byv
 bbx
 bcm
 bdd
 beb
-byD
+byv
 aZT
 bfK
 bgg
@@ -82171,14 +82165,14 @@ aWQ
 aXv
 aYc
 aYW
-byw
+byv
 baI
 bby
 bcn
 bde
 bec
 beH
-byF
+byv
 bfK
 bgg
 bgU
@@ -82685,14 +82679,14 @@ aWS
 aXv
 aYe
 aYW
-byx
+byv
 baK
 bbA
 bcp
 bdg
 bee
 beJ
-byG
+byv
 bfK
 bgi
 bgU
@@ -82943,13 +82937,13 @@ aSq
 aYc
 aYW
 aZT
-byz
-byA
-byB
+byv
+byv
+byv
 bdh
-byC
-byE
-byH
+byv
+byv
+byv
 bfM
 bgi
 bgV


### PR DESCRIPTION
Fixes #172 

:cl: Purpose
del: Omega: Removes superfluous medical beaker.
add: Omega: Adds wrench in medical
add: Omega: Adds more medical belts
add: Omega: Adds Robotics R&D console to robotics
add: Omega: Adds a toolbox to R&D
fix: Omega: Fixes an atmos console without density
tweak: Omega: Fixes a couple of bugged cameras, one of the bridge and one in arrivals.
/ :cl: