### PR TITLE
QOL change for Cargo

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -7,6 +7,7 @@
 	density = FALSE
 	anchored = TRUE
 	layer = ABOVE_MOB_LAYER
+	CanAtmosPass = ATMOS_PASS_NO
 	var/state = PLASTIC_FLAPS_NORMAL
 
 /obj/structure/plasticflaps/examine(mob/user)


### PR DESCRIPTION
Makes flaps not pass atmos. This is how Paradise already handles this, and it has been frequently requested for Oracle.

:cl: Purpose
tweak: Plastic flaps no longer leak air
/ :cl: 