### PR TITLE
Fixes the AI Chamber door name

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5045,7 +5045,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	locked = 1;
-	name = "MiniSat Chamber";
+	name = "AI Chamber";
 	req_access_txt = "16"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{


### PR DESCRIPTION
Fixes #157 

Done without having to even open DM, Just edit one line in notepad++.

:cl: AffectedArc07
tweak: OmegaStation AI Chamber door is no longer called MiniSat Chamber
/:cl: