### PR TITLE
No screaming mimes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -1,5 +1,6 @@
 #define EMOTE_VISIBLE 1
 #define EMOTE_AUDIBLE 2
+#define EMOTE_SPEAK 3
 
 /datum/emote
 	var/key = "" //What calls the emote
@@ -15,7 +16,6 @@
 	var/message_param = "" //Message to display if a param was given
 	var/emote_type = EMOTE_VISIBLE //Whether the emote is visible or audible
 	var/restraint_check = FALSE //Checks if the mob is restrained before performing the emote
-	var/muzzle_ignore = FALSE //Will only work if the emote is EMOTE_AUDIBLE
 	var/list/mob_type_allowed_typecache //Types that are allowed to use that emote
 	var/list/mob_type_blacklist_typecache //Types that are NOT allowed to use that emote
 	var/stat_allowed = CONSCIOUS
@@ -73,10 +73,10 @@
 
 /datum/emote/proc/select_message_type(mob/user)
 	. = message
-	if(!muzzle_ignore && user.is_muzzled() && emote_type == EMOTE_AUDIBLE)
-		return "makes a [pick("strong ", "weak ", "")]noise."
 	if(user.mind && user.mind.miming && message_mime)
 		. = message_mime
+	if(!user.can_speak() && !message_mime && emote_type == EMOTE_SPEAK || user.is_muzzled() && emote_type == EMOTE_SPEAK)
+		return "makes a [pick("strong ", "weak ", "loud ")]noise."
 	if(isalienadult(user) && message_alien)
 		. = message_alien
 	else if(islarva(user) && message_larva)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -73,10 +73,10 @@
 
 /datum/emote/proc/select_message_type(mob/user)
 	. = message
+	if(!user.can_speak() && emote_type == EMOTE_SPEAK || user.is_muzzled() && emote_type == EMOTE_SPEAK)
+		return "makes a [pick("strong ", "weak ", "loud ")]noise."
 	if(user.mind && user.mind.miming && message_mime)
 		. = message_mime
-	if(!user.can_speak() && !message_mime && emote_type == EMOTE_SPEAK || user.is_muzzled() && emote_type == EMOTE_SPEAK)
-		return "makes a [pick("strong ", "weak ", "loud ")]noise."
 	if(isalienadult(user) && message_alien)
 		. = message_alien
 	else if(islarva(user) && message_larva)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -19,7 +19,6 @@
 	key = "clap"
 	key_third_person = "claps"
 	message = "claps."
-	muzzle_ignore = TRUE
 	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
@@ -34,7 +33,7 @@
 	key_third_person = "moans"
 	message = "moans!"
 	message_mime = "appears to moan!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/carbon/roll
 	key = "roll"
@@ -55,6 +54,7 @@
 	key_third_person = "screeches"
 	message = "screeches."
 	mob_type_allowed_typecache = list(/mob/living/carbon/monkey)
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/carbon/screech/run_emote(mob/user, params)
 	if(..())

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -5,7 +5,7 @@
 	key = "cry"
 	key_third_person = "cries"
 	message = "cries."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/carbon/human/dap
 	key = "dap"
@@ -22,7 +22,7 @@
 	key = "grumble"
 	key_third_person = "grumbles"
 	message = "grumbles!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/carbon/human/handshake
 	key = "handshake"
@@ -43,7 +43,7 @@
 	key = "mumble"
 	key_third_person = "mumbles"
 	message = "mumbles!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -40,7 +40,7 @@
 	key = "choke"
 	key_third_person = "chokes"
 	message = "chokes!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/cross
 	key = "cross"
@@ -52,7 +52,7 @@
 	key = "chuckle"
 	key_third_person = "chuckles"
 	message = "chuckles."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/collapse
 	key = "collapse"
@@ -153,13 +153,13 @@
 	key = "gag"
 	key_third_person = "gags"
 	message = "gags."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/gasp
 	key = "gasp"
 	key_third_person = "gasps"
 	message = "gasps!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/giggle
@@ -167,14 +167,13 @@
 	key_third_person = "giggles"
 	message = "giggles."
 	message_mime = "giggles silently!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/glare
 	key = "glare"
 	key_third_person = "glares"
 	message = "glares."
 	message_param = "glares at %t."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/grin
 	key = "grin"
@@ -186,6 +185,7 @@
 	key_third_person = "groans"
 	message = "groans!"
 	message_mime = "appears to groan!"
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/grimace
 	key = "grimace"
@@ -209,7 +209,7 @@
 	key = "laugh"
 	key_third_person = "laughs"
 	message = "laughs."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/look
 	key = "look"
@@ -234,31 +234,27 @@
 	key = "pout"
 	key_third_person = "pouts"
 	message = "pouts."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/scowl
 	key = "scowl"
 	key_third_person = "scowls"
 	message = "scowls."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shake
 	key = "shake"
 	key_third_person = "shakes"
 	message = "shakes their head."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shiver
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "shivers."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sigh
 	key = "sigh"
 	key_third_person = "sighs"
 	message = "sighs."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/sit
 	key = "sit"
@@ -286,7 +282,7 @@
 	key_third_person = "snores"
 	message = "snores."
 	message_mime = "sleeps soundly."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/stare
 	key = "stare"
@@ -345,6 +341,7 @@
 	key_third_person = "whimpers"
 	message = "whimpers."
 	message_mime = "appears hurt."
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/wsmile
 	key = "wsmile"
@@ -355,7 +352,7 @@
 	key = "yawn"
 	key_third_person = "yawns"
 	message = "yawns."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 
 /datum/emote/living/custom
 	key = "me"
@@ -479,11 +476,11 @@
 	key_third_person = "screams"
 	message = "screams."
 	message_mime = "acts out a scream!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 	cooldown = 100
 
 /datum/emote/living/scream/run_emote(mob/user, params)
-	if(!..())
+	if(!..() || !user.can_speak())
 		return
 
 	var/sound_to_play = 'sound/effects/mob_effects/goonstation/male_scream.ogg'
@@ -506,7 +503,7 @@
 	key_third_person = "coughs"
 	message = "coughs."
 	message_mime = "seems to be coughing!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 	cooldown = 60
 
 /datum/emote/living/cough/run_emote(mob/user, params)
@@ -529,7 +526,7 @@
 	key_third_person = "sneezes"
 	message = "sneezes!"
 	message_mime = "seems to be sneezing!"
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_SPEAK
 	cooldown = 60
 
 /datum/emote/living/sneeze/run_emote(mob/user, params)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -507,7 +507,7 @@
 	cooldown = 60
 
 /datum/emote/living/cough/run_emote(mob/user, params)
-	if(!..())
+	if(!..() || !user.can_speak())
 		return
 	var/sound_to_play = 'sound/effects/mob_effects/m_cough.ogg'
 	var/mob/living/carbon/human/H = user
@@ -530,7 +530,7 @@
 	cooldown = 60
 
 /datum/emote/living/sneeze/run_emote(mob/user, params)
-	if(!..())
+	if(!..() || !user.can_speak())
 		return
 	var/sound_to_play = 'sound/effects/mob_effects/sneeze.ogg'
 	var/mob/living/carbon/human/H = user


### PR DESCRIPTION
:cl: imsxz
add: adds a new emote type, "speaking". checks if you can speak.
tweak: makes a bunch of emotes "speaking" type emotes
tweak: makes some audible emotes into visible emotes
del: removes muzzle_ignore, replaced with a new emote type
/:cl:
Fixes #149 

Fixes mimes/otherwise mute people from being able to scream. Adds a new "speaking" emote type, which checks if you're able to speak, and changed a bunch of emotes to this type. I also removed a bunch of audible emotes where they didn't make sense, such as the previously audible glaring.

Additionally, I couldn't get the EMOTE_SPEAK to check properly for can_speak, people muted by chemicals and such still displayed "screams" instead of "makes a x noise" in chat, though it did stop the scream noise from playing which is the more important part.