### PR TITLE
Fixes small lesser ash drake oversight

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -384,6 +384,7 @@ Difficulty: Medium
 	melee_damage_lower = 30
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	loot = list()
+	crusher_loot = list()
 
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return


### PR DESCRIPTION
:cl: imsxz
fix: Fixes lesser ash drakes dropping loot when killed by kinetic crushers.
/:cl:

Megafauna drop special chests when killed with kinetic crushers. Lesser ash drakes aren't supposed to drop loot, as they aren't nearly as difficult to kill as a normal ash drake, but they were still able to drop crusher loot due to an oversight.

A neat exploit you could do with this is using the dragon shapeshift spell from lavaland, and letting a buddy kill you with a crusher over and over while reviving you somehow, for figuratively infinite ash drake chests.