### PR TITLE
Removes silicons remotely bolting de-powered doors.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -816,6 +816,8 @@
 					//drop door bolts
 					if(wires.is_cut(WIRE_BOLTS))
 						to_chat(usr, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
+					else if(!src.hasPower())
+						to_chat(usr, "Can't drop the door bolts - Power failure.")
 					else
 						bolt()
 				if(5)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -817,7 +817,7 @@
 					if(wires.is_cut(WIRE_BOLTS))
 						to_chat(usr, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
 					else if(!src.hasPower())
-						to_chat(usr, "Can't drop the door bolts - Power failure.")
+						to_chat(usr, "You can't drop the door bolts - Power failure.")
 					else
 						bolt()
 				if(5)


### PR DESCRIPTION
:cl: imsxz
fix: silicons can no longer REMOTELY bolt de-powered airlocks
/:cl:

Fixes #128 

While bolting de-powered airlocks is a feature, it should not be able to be done *remotely*, as there is no power to the AI (and cyborg) control part of the door.