### PR TITLE
Minor tweaks to clarification

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -100,7 +100,7 @@
 		return
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
-		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
+		"<span class='userdanger'>You devour [L]!</span>")
 	if(z != ZLEVEL_STATION && !client) //NPC monsters won't heal while on station
 		adjustBruteLoss(-L.maxHealth/2)
 	L.gib()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -186,7 +186,7 @@
 	to_chat(user, "<span class='notice'>You offer [src] to [SM]...</span>")
 	being_used = 1
 
-	var/list/candidates = pollCandidatesForMob("Do you want to play as [SM.name]?", ROLE_ALIEN, null, ROLE_ALIEN, 50, SM, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
+	var/list/candidates = pollCandidatesForMob("Do you want to play as [user]'s [SM.name]?", ROLE_ALIEN, null, ROLE_ALIEN, 50, SM, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
 	var/mob/dead/observer/theghost = null
 	if(candidates.len)
 		theghost = pick(candidates)


### PR DESCRIPTION
:cl: imsxz
tweak: ghosts are now informed of who they'll be serving as a xenobio mob
tweak: player controlled megafauna are no longer told that they're healed when devouring
/:cl:

Just some small tweaks to clarification, no actual balance changes. Player controlled megafauna don't actually heal when devouring, and usually just take damage when the gibs hit them. Also added a part to the sentient animal notification which serves two purposes: you'll know for sure that you're signing up for a sentient mob, and you know who you're gonna be serving. I've been baited by what I thought were admin ghost roles, only to end up in a mouse one too many times >:^( .