### PR TITLE
Balances Telebatons and Police Batons Stun/Cooldown Use Timers.

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -130,7 +130,7 @@
 				if(check_martial_counter(H, user))
 					return
 			playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
-			target.Knockdown(60)
+			target.Knockdown(40)
 			add_logs(user, target, "stunned", src)
 			src.add_fingerprint(user)
 			target.visible_message("<span class ='danger'>[user] has knocked down [target] with [src]!</span>", \
@@ -139,7 +139,7 @@
 				target.LAssailant = null
 			else
 				target.LAssailant = user
-			cooldown = world.time + 40
+			cooldown = world.time + 50
 
 /obj/item/melee/classic_baton/telescopic
 	name = "telescopic baton"


### PR DESCRIPTION
Changes Telebatons and Police Batons to not have a 6 second stun time with a 4 second time before they can be used again, thus preventing them from being
1) Better than stun batons
2) Able to permately stun lock someone


:cl: Xantholne
balance: Telebatons and Police Batons have had their stun times and use times changed.
/:cl: