### PR TITLE
Flightsuit Movement Adjustment one

### DIFF
--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -48,7 +48,7 @@
 
 	var/momentum_x = 0		//Realistic physics. No more "Instant stopping while barreling down a hallway at Mach 1".
 	var/momentum_y = 0
-	var/momentum_max = 500
+	var/momentum_max = 250
 	var/momentum_impact_coeff = 0.5	//At this speed you'll start coliding with people resulting in momentum loss and them being knocked back, but no injuries or knockdowns
 	var/momentum_impact_loss = 50
 	var/momentum_crash_coeff = 0.8	//At this speed if you hit a dense object, you will careen out of control, while that object will be knocked flying.

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -50,14 +50,14 @@
 	var/momentum_y = 0
 	var/momentum_max = 250
 	var/momentum_impact_coeff = 0.5	//At this speed you'll start coliding with people resulting in momentum loss and them being knocked back, but no injuries or knockdowns
-	var/momentum_impact_loss = 50
+	var/momentum_impact_loss = 25
 	var/momentum_crash_coeff = 0.8	//At this speed if you hit a dense object, you will careen out of control, while that object will be knocked flying.
 	var/momentum_drift_coeff = 0.04
 	var/momentum_speed = 0	//How fast we are drifting around
 	var/momentum_speed_x = 0
 	var/momentum_speed_y = 0
 	var/momentum_passive_loss = 4
-	var/momentum_gain = 20
+	var/momentum_gain = 10
 	var/drift_tolerance = 2
 
 	var/stabilizer = TRUE


### PR DESCRIPTION
So flightsuits got the crazy TG movement speed apparently. Not sure if adjusting the Max Momentum Var will slow it down, but considering the boost speed var is setup as an acceleration it seems this would make sense.

Since we are on half of TGs movement speed I cut it in half for now. I am tired and will do more testing later on on this particular suit.


:cl: EldritchSigma
tweak: Adjusted Flightsuit Movement speed from TG movement speed to Oracle movement speed...
/:cl:

