### PR TITLE
Easy Pipes (adds layered pipe subclasses for level designers)

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layered.dm
+++ b/code/modules/atmospherics/machinery/pipes/layered.dm
@@ -1,0 +1,315 @@
+/*
+Layered pipes - Same as the simple pipes, but includes definitions for the other two layers so mappers in the future don't want to kill themselves
+*/
+
+/*=====The big Kahunas=====*/
+
+//Supply 
+
+/obj/machinery/atmospherics/pipe/simple/supply/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/supply/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Scrubbers
+
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+//Supply Main
+
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+
+/*===== Equally important colored pipes =====*/
+
+//Grey/General
+
+/obj/machinery/atmospherics/pipe/simple/general/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/general/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/general/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/general/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Dark
+
+/obj/machinery/atmospherics/pipe/simple/dark/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/dark/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Brown
+
+/obj/machinery/atmospherics/pipe/simple/brown/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/brown/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/brown/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/brown/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Cyan
+
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Green
+/obj/machinery/atmospherics/pipe/simple/green/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/green/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/green/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/green/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Orange
+/obj/machinery/atmospherics/pipe/simple/orange/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/orange/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/orange/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/orange/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Purple 
+/obj/machinery/atmospherics/pipe/simple/purple/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/purple/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Violet
+/obj/machinery/atmospherics/pipe/simple/violet/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/violet/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/violet/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/violet/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Yellow
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5

--- a/code/modules/atmospherics/machinery/pipes/layered.dm
+++ b/code/modules/atmospherics/machinery/pipes/layered.dm
@@ -1,10 +1,11 @@
 /*
 Layered pipes - Same as the simple pipes, but includes definitions for the other two layers so mappers in the future don't want to kill themselves
+Now includes sanitized comments for the dead and soulless amoung us, purusing a hobby with questionable Purpose. 
 */
 
-/*=====The big Kahunas=====*/
+/*=== main Pipes ===*/
 
-//Supply 
+//sUpply 
 
 /obj/machinery/atmospherics/pipe/simple/supply/visible/bottom
 	layer = 2.3
@@ -30,7 +31,7 @@ Layered pipes - Same as the simple pipes, but includes definitions for the other
 	pixel_x = 5
 	pixel_y = 5
 
-//Scrubbers
+//scRubbers
 
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/bottom
 	layer = 2.3
@@ -56,7 +57,7 @@ Layered pipes - Same as the simple pipes, but includes definitions for the other
 	pixel_x = 5
 	pixel_y = 5
 	
-//Supply Main
+//supPly Main
 
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible/bottom
 	layer = 2.3
@@ -83,9 +84,9 @@ Layered pipes - Same as the simple pipes, but includes definitions for the other
 	pixel_y = 5
 	
 
-/*===== Equally important colored pipes =====*/
+/*===== equally impOrtant colored pipeS =====*/
 
-//Grey/General
+//Grey/GEneral
 
 /obj/machinery/atmospherics/pipe/simple/general/visible/bottom
 	layer = 2.3
@@ -264,7 +265,7 @@ Layered pipes - Same as the simple pipes, but includes definitions for the other
 	pixel_x = 5
 	pixel_y = 5
 
-//Violet
+//vIolet
 /obj/machinery/atmospherics/pipe/simple/violet/visible/bottom
 	layer = 2.3
 	piping_layer = 1

--- a/code/modules/atmospherics/machinery/pipes/layeredmanifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/layeredmanifold4w.dm
@@ -1,10 +1,9 @@
 /* Four-way manifolds */
 
-/*===== Haute tayau *kisses fingers* ===== */
+/*===== Main Pipes =====*/
 //Supply
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible/bottom
-	level = PIPE_VISIBLE_LEVEL
 	layer = 2.3
 	piping_layer = 1
 	pixel_x = -5
@@ -59,7 +58,6 @@
 //Supply Main
 
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/bottom
-	level = PIPE_VISIBLE_LEVEL
 	layer = 2.3
 	piping_layer = 1
 	pixel_x = -5
@@ -83,7 +81,7 @@
 	piping_layer = 3
 	pixel_x = 5
 	
-/*===== Amor colores =====*/ 
+/*===== Additional, equally interesting colors =====*/ 
 
 //Grey/General
 

--- a/code/modules/atmospherics/machinery/pipes/layeredmanifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/layeredmanifold4w.dm
@@ -1,0 +1,315 @@
+/* Four-way manifolds */
+
+/*===== Haute tayau *kisses fingers* ===== */
+//Supply
+
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/bottom
+	level = PIPE_VISIBLE_LEVEL
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+//Scrubbers
+
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+//Supply Main
+
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/bottom
+	level = PIPE_VISIBLE_LEVEL
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	
+/*===== Amor colores =====*/ 
+
+//Grey/General
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Dark
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Brown
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Cyan
+
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Green
+/obj/machinery/atmospherics/pipe/manifold4w/green/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/green/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/green/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/green/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Orange
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Purple 
+/obj/machinery/atmospherics/pipe/manifold4w/purple/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/purple/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Violet
+/obj/machinery/atmospherics/pipe/manifold4w/violet/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/violet/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Yellow
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5

--- a/code/modules/atmospherics/machinery/pipes/layeredmanifolds.dm
+++ b/code/modules/atmospherics/machinery/pipes/layeredmanifolds.dm
@@ -1,6 +1,6 @@
-/* Layered manifolds not to be confused with layermanifold.dm that's something diffirent I'm so sorry */
+/* Layered manifolds not to be confused with layermanifold.dm */
 
-/*===== The Big Cheeses =====*/
+/*===== Maine Pipes =====*/
 //Supply 
 
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/bottom
@@ -80,7 +80,7 @@
 	pixel_y = 5
 
 	
-/*===== Other delicacies =====*/
+/*===== Other delightful colors =====*/
 	
 //Grey/General
 

--- a/code/modules/atmospherics/machinery/pipes/layeredmanifolds.dm
+++ b/code/modules/atmospherics/machinery/pipes/layeredmanifolds.dm
@@ -1,0 +1,312 @@
+/* Layered manifolds not to be confused with layermanifold.dm that's something diffirent I'm so sorry */
+
+/*===== The Big Cheeses =====*/
+//Supply 
+
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Scrubbers
+	
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+//Supply Main
+
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+	
+/*===== Other delicacies =====*/
+	
+//Grey/General
+
+/obj/machinery/atmospherics/pipe/manifold/general/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/general/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Dark
+
+/obj/machinery/atmospherics/pipe/manifold/dark/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/dark/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/dark/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/dark/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Brown
+
+/obj/machinery/atmospherics/pipe/manifold/brown/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/brown/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/brown/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/brown/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Cyan
+
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Green
+/obj/machinery/atmospherics/pipe/manifold/green/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/green/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Orange
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Purple 
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Violet
+/obj/machinery/atmospherics/pipe/manifold/violet/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/violet/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/violet/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/violet/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+//Yellow
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden/bottom
+	layer = 2.3
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden/top
+	layer = 2.4
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5


### PR DESCRIPTION
Title says it all.  
Lets users easily add top and bottom 'layers' onto pipes, letting them visualize their atmospherics layouts much more easily, and deploy them with improved efficiency.

![dreamseeker_2017-10-28_20-06-00](https://user-images.githubusercontent.com/8153882/32146231-06bb3a2a-bca2-11e7-933c-7e397854d584.png) 
_IT'S SO PRETTY_

https://gfycat.com/SoulfulSecretGreathornedowl

