### PR TITLE
Plasma Cutter Nerf, lower rock pierce. Yes you can still pierce Liz- …

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -204,7 +204,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/pressure_decrease_active = FALSE
 	var/pressure_decrease = 0.25
-	var/mine_range = 3 //mines this many additional tiles of rock
+	var/mine_range = 1 //mines this many additional tiles of rock
 
 /obj/item/projectile/plasma/Initialize()
 	. = ..()
@@ -227,7 +227,7 @@
 /obj/item/projectile/plasma/adv
 	damage = 28
 	range = 5
-	mine_range = 5
+	mine_range = 3
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 40


### PR DESCRIPTION
…I mean ashwalkers with it.

So proposing this nerf to the plasmacutters because they are really breaking mining. They got an immense range and can pierce up to 5 rocks (the advanced variant). Even more if they are hitting diagonals. This should lower their efficiency while not making them completly useless. They are about as viable now as blast upgrades for the KA or the rarely used adv. Kinetic Resonator or the damage wise superior Kinetic Crusher and not just a straight upgrade from ALL the miners tools. Mech Cutter keeps its insane range and low rock pierce. If you dont have a super cell installed on your mech it drains the mech rather fast.  



:cl: Eldritch Sigma
balance: lowered plasmacutters and adv. plasmacutters mining pierce by a bit. Down to 1/3 of old range of the reg. one and 40% less pierce on the advanced. Still retain the 5 tile range. Still usefull for mining. As usual let me know if you still use it.
/:cl:

