### PR TITLE
Plasmacutter tech and price increase

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -174,9 +174,9 @@ other types of metals and chemistry for reagents).
 	name = "Plasma Cutter"
 	desc = "You could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	id = "plasmacutter"
-	req_tech = list("materials" = 3, "plasmatech" = 3, "magnets" = 2)
+	req_tech = list("materials" = 4, "plasmatech" = 4, "magnets" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 400)
+	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 400, MAT_URANIUM = 250, MAT_SILVER = 500)
 	build_path = /obj/item/gun/energy/plasmacutter
 	category = list("Mining Designs")
 
@@ -184,9 +184,9 @@ other types of metals and chemistry for reagents).
 	name = "Advanced Plasma Cutter"
 	desc = "It's an advanced plasma cutter, oh my god."
 	id = "plasmacutter_adv"
-	req_tech = list("materials" = 4, "plasmatech" = 4, "engineering" = 2, "combat" = 3, "magnets" = 3)
+	req_tech = list("materials" = 5, "plasmatech" = 4, "engineering" = 4, "combat" = 4, "magnets" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500)
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500, MAT_URANIUM = 500, MAT_SILVER = 1250)
 	build_path = /obj/item/gun/energy/plasmacutter/adv
 	category = list("Mining Designs")
 


### PR DESCRIPTION
While we are at it I looked at the price of the plasmacutters. They are really really low. Heck even tech requirements are dirt simple. You can print the regular ones even without the need of mining like 4 mins into the round. Not anymore. Considering they accelerate a bolt of plasma they now need a room temperature superconducting alloy made out of a diversity of transition metals (metal), uranium and silver. Well thats the fluff behind that change and why they should cost silver and uranium in the first place. The other one just needs a very very good conductor. Hence why it gets silver added as requirement. Oh and more techlevels so you cant hand the regular one out like cotton candy at roundstart since they are basicly better welders aswell.

:cl: EldritchSigma
balance: Increased techlevel requirements and resource requirements for the portable plasmacutters so they are more in line with the other mining tools.
/:cl:


