### PR TITLE
Remove some unneeded null checks in lighting

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -270,8 +270,6 @@
 		source_turf.luminosity = Ceiling(light_range)
 		for(T in view(Ceiling(light_range), source_turf))
 			for (thing in T.get_corners(source_turf))
-				if(!thing)
-					continue
 				C = thing
 				corners[C] = 0
 			turfs += T
@@ -293,8 +291,6 @@
 	LAZYINITLIST(effect_str)
 	if (needs_update == LIGHTING_VIS_UPDATE)
 		for (thing in  corners - effect_str) // New corners
-			if(!thing)
-				continue
 			C = thing
 			LAZYADD(C.affecting, src)
 			if (!C.active)
@@ -304,8 +300,6 @@
 	else
 		L = corners - effect_str
 		for (thing in L) // New corners
-			if(!thing)
-				continue
 			C = thing
 			LAZYADD(C.affecting, src)
 			if (!C.active)
@@ -314,8 +308,6 @@
 			APPLY_CORNER(C)
 
 		for (thing in corners - L) // Existing corners
-			if(!thing)
-				continue
 			C = thing
 			if (!C.active)
 				effect_str[C] = 0
@@ -324,8 +316,6 @@
 
 	L = effect_str - corners
 	for (thing in L) // Old, now gone, corners.
-		if(!thing)
-			continue
 		C = thing
 		REMOVE_CORNER(C)
 		LAZYREMOVE(C.affecting, src)


### PR DESCRIPTION
From MSO at upstream: https://github.com/tgstation/tgstation/pull/32137

These weren't needed because T.get_corners will either return a null list (preventing the for from even running) or return a full corners list with no nulls, and this line ran thousands of times per second during high lighting activity, and was pretty high up in the line by line profile of lighting for what was basically a noop.
