### PR TITLE
Fixes excessive overlay churn

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -131,9 +131,10 @@
 		var/obj/item/clothing/shoes/S = H.shoes
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			entered_dirs|= H.dir
-			shoe_types |= H.shoes.type
-	update_icon()
+			shoe_types |= S.type
+			if (!(entered_dirs & H.dir))
+				entered_dirs |= H.dir
+				update_icon()
 
 /obj/effect/decal/cleanable/blood/footprints/Uncrossed(atom/movable/O)
 	if(ishuman(O))
@@ -141,9 +142,10 @@
 		var/obj/item/clothing/shoes/S = H.shoes
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			exited_dirs|= H.dir
-			shoe_types |= H.shoes.type
-	update_icon()
+			shoe_types  |= S.type
+			if (!(exited_dirs & H.dir))
+				exited_dirs |= H.dir
+				update_icon()
 
 /obj/effect/decal/cleanable/blood/footprints/update_icon()
 	cut_overlays()
@@ -182,4 +184,3 @@
 	if((blood_state != BLOOD_STATE_OIL) && (blood_state != BLOOD_STATE_NOT_BLOODY))
 		return 1
 	return 0
-


### PR DESCRIPTION
From MSO at upstream: https://github.com/tgstation/tgstation/pull/32065

Adding an overlay on every cross and uncross of every player (with how bloody the station gets this is called on just about every fucking movement, some times multiple times if there are multiple types of stains (oil, blood, alien, etc)) is an excessive as fuck amount of chern in the overlay subsystem.

This was almost always noops that ran on cross and uncross, only they still required an overlay chern and appearance recalculate.

This is likely the cause of `compile_overlays` being so high on profile, as well as some of the mc lag.