### PR TITLE
Dummies used for preference setup always immediately compile their overlays

### DIFF
--- a/code/controllers/subsystem/processing/overlays.dm
+++ b/code/controllers/subsystem/processing/overlays.dm
@@ -26,13 +26,32 @@ PROCESSING_SUBSYSTEM_DEF(overlays)
 	overlay_icon_cache = SSoverlays.overlay_icon_cache
 	processing = SSoverlays.processing
 
+#define COMPILE_OVERLAYS(A)\
+	var/list/oo = A.our_overlays;\
+	var/list/po = A.priority_overlays;\
+	if(LAZYLEN(po)){\
+		if(LAZYLEN(oo)){\
+			A.overlays = oo + po;\
+		}\
+		else{\
+			A.overlays = po;\
+		}\
+	}\
+	else if(LAZYLEN(oo)){\
+		A.overlays = oo;\
+	}\
+	else{\
+		A.overlays.Cut();\
+	}\
+	A.flags_1 &= ~OVERLAY_QUEUED_1
+
 /datum/controller/subsystem/processing/overlays/fire(resumed = FALSE, mc_check = TRUE)
 	var/list/processing = src.processing
 	while(processing.len)
 		var/atom/thing = processing[processing.len]
 		processing.len--
 		if(thing)
-			thing.compile_overlays()
+			COMPILE_OVERLAYS(thing)
 		if(mc_check)
 			if(MC_TICK_CHECK)
 				break
@@ -43,19 +62,6 @@ PROCESSING_SUBSYSTEM_DEF(overlays)
 	if(processing.len)
 		testing("Flushing [processing.len] overlays")
 		fire(mc_check = FALSE)	//pair this thread up with the MC to get extra compile time
-
-/atom/proc/compile_overlays()
-	var/list/oo = our_overlays
-	var/list/po = priority_overlays
-	if(LAZYLEN(po) && LAZYLEN(oo))
-		overlays = oo + po
-	else if(LAZYLEN(oo))
-		overlays = oo
-	else if(LAZYLEN(po))
-		overlays = po
-	else
-		overlays.Cut()
-	flags_1 &= ~OVERLAY_QUEUED_1
 
 /proc/iconstate2appearance(icon, iconstate)
 	var/static/image/stringbro = new()

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -60,6 +60,7 @@
 	if(previewJob)
 		mannequin.job = previewJob.title
 		previewJob.equip(mannequin, TRUE)
+	COMPILE_OVERLAYS(mannequin)
 	CHECK_TICK
 	preview_icon = icon('icons/effects/effects.dmi', "nothing")
 	preview_icon.Scale(48+32, 16+32)


### PR DESCRIPTION
From Cyberboss at upstream: https://github.com/tgstation/tgstation/pull/31987 & https://github.com/tgstation/tgstation/pull/31267


Performance improvements also, makes the character preferences dummy always populate correctly.