### PR TITLE
unrelated plasma cutter nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -141,12 +141,7 @@
 	if(istype(A, /obj/item/stack/sheet/mineral/plasma))
 		var/obj/item/stack/sheet/S = A
 		S.use(1)
-		cell.give(1000)
-		recharge_newshot(1)
-		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
-	else if(istype(A, /obj/item/ore/plasma))
-		qdel(A)
-		cell.give(500)
+		cell.give(100)
 		recharge_newshot(1)
 		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
 	else


### PR DESCRIPTION
:cl: imsxz
balance: removes charging plasma cutters via ore
balance: plasma sheets now recharges plasma cutter by 10%, rather than 100%
/:cl:

Do not merge if #206 or #207 are merged.

This is my personal suggestion to nerf the plasma cutter, feel free to discuss.