### PR TITLE
Removes Plasmamen, Pod People & Slime People as round-start races.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -400,10 +400,10 @@ ROUNDSTART_RACES human
 
 ## Races that are okay-ish on the station. Safe to enable.
 ROUNDSTART_RACES unathi
-ROUNDSTART_RACES plasmaman
-ROUNDSTART_RACES slime
+#ROUNDSTART_RACES plasmaman
+#ROUNDSTART_RACES slime
 ROUNDSTART_RACES ethari
-ROUNDSTART_RACES pod
+#ROUNDSTART_RACES pod
 
 ## Races that aren't on the station by default.
 #ROUNDSTART_RACES jelly


### PR DESCRIPTION
:cl: Purpose2
del: Removes Plasmamen, Pod People & Slime People as round-start races.
/:cl:

These aren't exactly interesting, or even particularly balanced at the moment. Removing this from being playable at round-start allow us to do more interesting things with them in things like adventure zones and admin events.