### PR TITLE
Fixes directional character previews

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -779,7 +779,7 @@ The _flatIcons list is a cache for generated icon files.
 	if(A.alpha < 255)
 		flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 
-	return icon(flat, "", SOUTH)
+	return icon(flat, "", curdir)
 
 /proc/getIconMask(atom/A)//By yours truly. Creates a dynamic mask for a mob/whatever. /N
 	var/icon/alpha_mask = new(A.icon,A.icon_state)//So we want the default icon and icon state of A.


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/32332 from upstream

:cl: deathride58
fix: Directional character icon previews now function properly. Other things relying on getflaticon probably work with directional icons again, as well.
/:cl: