### PR TITLE
You can now light cigars on burning people

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -234,6 +234,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
 		return ..()
+	if(M.on_fire && !lit)
+		light("<span class='notice'>[user] lights [src] with [M]'s burning body. What a cold-blooded badass.</span>")
+		return
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M)
 	if(lit && cig && user.a_intent == INTENT_HELP)
 		if(cig.lit)


### PR DESCRIPTION
Porting https://github.com/tgstation/tgstation/pull/31081 from upstream

:cl: RandomMarine
add: You can now light your cigs with people that are on fire. The surgeon general is spinning in their grave.
/:cl: