### PR TITLE
TOXINLOVER species now take toxin damage from not having a liver

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -430,6 +430,13 @@
 	if(reagents.get_reagent_amount("corazone"))//corazone is processed here an not in the liver because a failing liver can't metabolize reagents
 		reagents.remove_reagent("corazone", 0.4) //corazone slowly deletes itself.
 		return
-	adjustToxLoss(8)
+	var/dealt_damage = FALSE
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(TOXINLOVER in H.dna.species.species_traits)
+			adjustToxLoss(-8)
+			dealt_damage = TRUE
+	if(!dealt_damage)
+		adjustToxLoss(8)
 	if(prob(30))
 		to_chat(src, "<span class='notice'>You feel confused and nauseous...</span>")//actual symptoms of liver failure


### PR DESCRIPTION
:cl: Flatty
tweak: Slime People now take damage from not having a liver
/:cl:

Not much to say. TOXINLOVER species now take damage when they don't have a liver. The fact that you can't process chems is the way the game works, so that one's hardly a bug, though we might want to look into that later down the road, who knows.



fixes #187 