### PR TITLE
Fixes traitor objectives for non-existent items

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -452,7 +452,7 @@ GLOBAL_LIST_EMPTY(possible_items)
 /datum/objective/steal/find_target()
 	var/approved_targets = list()
 	for(var/datum/objective_item/possible_item in GLOB.possible_items)
-		if(is_unique_objective(possible_item.targetitem) && !(owner.current.mind.assigned_role in possible_item.excludefromjob))
+		if(	is_unique_objective(possible_item.targetitem) && !(owner.current.mind.assigned_role in possible_item.excludefromjob) &&	possible_item.TargetExists())
 			approved_targets += possible_item
 	return set_target(safepick(approved_targets))
 
@@ -876,6 +876,3 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/changeling_team_objective/impersonate_department/impersonate_heads
 	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead"
 	command_staff_only = TRUE
-
-
-

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -14,6 +14,11 @@
 /datum/objective_item/proc/TargetExists()
 	return TRUE
 
+/datum/objective_item/steal/TargetExists()
+	if (locate(targetitem))
+		return TRUE
+	return FALSE
+
 /datum/objective_item/steal/New()
 	..()
 	if(TargetExists())


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/202160/32693511-149c6f6a-c724-11e7-941f-b911e31d6aae.png)

:cl: AndrewMontagne
fix: You can no longer get a steal objective for a non-existent item.
/:cl: