### PR TITLE
Fixes Megafauna Supermatter Immunity

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -569,6 +569,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 	Consume(AM)
 
 /obj/machinery/power/supermatter_shard/proc/Consume(atom/movable/AM)
+	if(istype(AM, /mob/living/simple_animal/hostile/megafauna))
+		var/mob/living/simple_animal/hostile/megafauna/MF = AM
+		MF.health = 0 //Snowflakey, but this makes them vulnerable to being dusted. >:)
 	if(isliving(AM))
 		var/mob/living/user = AM
 		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)].")


### PR DESCRIPTION
Fixes #201

![dust](https://user-images.githubusercontent.com/202160/32694037-422ea754-c72e-11e7-8af6-06e795bb0308.gif)

:cl: AndrewMontagne
fix: Megafauna are no longer supermatter immune.
/:cl:
