### PR TITLE
Shorter blurry vision when you get out of crit

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -370,7 +370,7 @@
 	var/list/holy_heck_the_ouch_list = list("PLEASE, JUST END THE PAIN!", "GOOD GOD, MAKE THE PAIN STOP!", "AGH, IT HURTS!!!")
 
 	stuttering = max(stuttering, 4)
-	blur_eyes(50)
+	blur_eyes(3)
 
 	switch(shock_stage)
 		if(30)


### PR DESCRIPTION
3 seconds after you're back to >0 HP you get your vision back; not 50.

And yes, this proc doesn't *add* 50 seconds, it *sets* 50 seconds.