### PR TITLE
Fixes deadchat shitcode

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -27,6 +27,6 @@
 		if(isnewplayer(M))
 			continue
 		if (M.stat == DEAD || (M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-			M.show_message(rendered, 2)
+			to_chat(M, rendered)
 
 	SSblackbox.add_details("admin_verb","Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
This is not the right proc for sending messages. >:C
Admin-only.

Now we can see DSAY when our mob is deaf or passed out.