### PR TITLE
Can't operate without a table

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -82,7 +82,7 @@
 	var/be_nice = FALSE
 	if(lying && user.a_intent == INTENT_HELP)
 
-		if(I.sharpness)
+		if(I.sharpness && can_operate(src))
 			attempt_initiate_surgery(I, src, user)
 			be_nice = TRUE
 		if(surgeries.len && user != src)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -90,16 +90,15 @@
 
 
 
-/proc/get_location_modifier(mob/M)
+/proc/can_operate(mob/M)
 	var/turf/T = get_turf(M)
 	if(locate(/obj/structure/table/optable, T))
-		return 1
+		return TRUE
 	else if(locate(/obj/structure/table, T))
-		return 0.8
+		return TRUE
 	else if(locate(/obj/structure/bed, T))
-		return 0.7
-	else
-		return 0.5
+		return TRUE
+
 
 
 /proc/get_location_accessible(mob/M, location)


### PR DESCRIPTION
You no longer start operating on people during a fight unless they're on a table.

That proc is actually completely unused, so nomming it for this is fine.