### PR TITLE
PDA slot > ID slot

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -225,7 +225,7 @@
 
 	if(!slot_priority)
 		slot_priority = list( \
-			slot_back, slot_wear_id, slot_wear_pda,\
+			slot_back, slot_wear_pda, slot_wear_id,\
 			slot_w_uniform, slot_wear_suit,\
 			slot_wear_mask, slot_head, slot_neck,\
 			slot_shoes, slot_gloves,\


### PR DESCRIPTION
It's just better, okay.

When you press E the PDA slot will be prioritized. The only consequence is putting a PDA on the PDA slot instead of the ID slot. o7o7o7o7o7