### PR TITLE
Tweaks the light breaking event

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,8 +3,8 @@
 	typepath = /datum/round_event/electrical_storm
 	earliest_start = 6000
 	min_players = 5
-	weight = 40
-	alertadmins = 0
+	weight = 30
+	alertadmins = 1
 
 /datum/round_event/electrical_storm
 	var/lightsoutAmount	= 1


### PR DESCRIPTION
Reduces it a bit, but more importantly, now flags it with admins so we can cancel it if we want.

This is only really a problem on Omega, and we might want to up its weight again once pop picks up.