### PR TITLE
Advanced E-Gun has a slight malfunction chance again.

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -130,11 +130,11 @@
 		switch(fail_tick)
 			if(0 to 200)
 				fail_tick += (2*(fail_chance))
-				M.rad_act(20)
+				M.rad_act(40)
 				to_chat(M, "<span class='userdanger'>Your [name] emits alot of heat...</span>")
 			if(201 to INFINITY)
 				SSobj.processing.Remove(src)
-				M.rad_act(40)
+				M.rad_act(60)
 				crit_fail = 1
 				to_chat(M, "<span class='userdanger'>Your [name]'s micro-breeder reactor overloads!</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -134,7 +134,7 @@
 				to_chat(M, "<span class='userdanger'>Your [name] emits alot of heat...</span>")
 			if(201 to INFINITY)
 				SSobj.processing.Remove(src)
-				M.rad_act(60)
+				M.rad_act(80)
 				crit_fail = 1
 				to_chat(M, "<span class='userdanger'>Your [name]'s micro-breeder reactor overloads!</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -111,8 +111,8 @@
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
 	selfcharge = 1
-	var/fail_tick = 0
-	var/fail_chance = 0
+	var/fail_tick = 1
+	var/fail_chance = 1
 
 /obj/item/gun/energy/e_gun/nuclear/process()
 	if(fail_tick > 0)
@@ -130,11 +130,11 @@
 		switch(fail_tick)
 			if(0 to 200)
 				fail_tick += (2*(fail_chance))
-				M.rad_act(40)
+				M.rad_act(20)
 				to_chat(M, "<span class='userdanger'>Your [name] feels warmer.</span>")
 			if(201 to INFINITY)
 				SSobj.processing.Remove(src)
-				M.rad_act(80)
+				M.rad_act(40)
 				crit_fail = 1
 				to_chat(M, "<span class='userdanger'>Your [name]'s reactor overloads!</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -131,12 +131,12 @@
 			if(0 to 200)
 				fail_tick += (2*(fail_chance))
 				M.rad_act(20)
-				to_chat(M, "<span class='userdanger'>Your [name] feels warmer.</span>")
+				to_chat(M, "<span class='userdanger'>Your [name] emits alot of heat...</span>")
 			if(201 to INFINITY)
 				SSobj.processing.Remove(src)
 				M.rad_act(40)
 				crit_fail = 1
-				to_chat(M, "<span class='userdanger'>Your [name]'s reactor overloads!</span>")
+				to_chat(M, "<span class='userdanger'>Your [name]'s micro-breeder reactor overloads!</span>")
 
 /obj/item/gun/energy/e_gun/nuclear/emp_act(severity)
 	..()


### PR DESCRIPTION
Since nerfing the firerate would nerf the E-Guns firerate aswell and just increasing the recharge time would basicly just changing one number without any other interactions other "Duh carry another" I propose to reactivate the irradiation and EMP fail chance on the E-Gun. 

What it is supposed to do is to have fail ticks. Each time you use the gun or when it recharges itself (or changes its state in any way, yes this should include EMPs) it has a chance to run into a fail tick. If a fail tick happens a few things can happen. It can irradiate the user, requiring the user to get some Potassium Iodide. It can strongly irradiate the user which might result in more severe things than just a few radiation burns. On getting hit by an EMP it runs the same failchecks but at a much higher likehood to pass.

The reason for this nerf is that the AEG currently has an insane firerate, fast recharge and a cheap price which basicly outclasses everything sec can get short of ballistics for the occasional esword using prick. Sec will visit the chemist in medbay and ask for Anti-Rad pills containing charcoal, saline glucose and of course Potassium Iodide to heal the burns. Or you know... actually wear a damn hardsuit or heavier armor from the armory if they intend on using this weapon mainly. It is an experimental military grade weapon and should not be used without any good reason. That should stop Captains like that fucking Thali on getting one every other round because it just outclasses the E-Gun and even the Antique Laser by far at the moment.




:cl: EldritchSigma
tweak: The AEG now irradiates you again if you use it overextensivly.
experiment: Nanotrasen Weapon Developement Department in collaboration with Omegacorp Arms found out that the new Advanced Energy Gun, commonly known as AEG, has a severe flaw in its design. The Thorium Breeder Reactor used to make it a self sufficient weapon cannot be shielded efficiently without making this weapon alot bulkier and impracticable. Nanotrasen recommends that any personell intending to use it should inform themself about prolonged exposure to irradiation and how to treat radiation exposure. 
/:cl:

