### PR TITLE
Makes the Lasercannon printable again with tweaks to reqs.

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -256,7 +256,7 @@
 	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 5, engineering = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 3500, MAT_URANIUM = 2000, MAT_SILVER = 2000, MAT_GOLD = 500)
-	build_path = /obj/item/weapon/gun/energy/lasercannon
+	build_path = /obj/item/gun/energy/lasercannon
 	category = list("Weapons")
 	lockbox_access = list(ACCESS_ARMORY)
 	

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -248,3 +248,15 @@
 	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	category = list("Weapons")
 	lockbox_access = list(ACCESS_ARMORY)
+	
+/datum/design/lasercannon
+	name = "Accelerator Laser Cannon"
+	desc = "A heavy duty laser cannon. It does more damage the farther away the target is."
+	id = "lasercannon"
+	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 5, engineering = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 3500, MAT_URANIUM = 2000, MAT_SILVER = 2000, MAT_GOLD = 500)
+	build_path = /obj/item/weapon/gun/energy/lasercannon
+	category = list("Weapons")
+	lockbox_access = list(ACCESS_ARMORY)
+	

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -253,7 +253,7 @@
 	name = "Accelerator Laser Cannon"
 	desc = "A heavy duty laser cannon. It does more damage the farther away the target is."
 	id = "lasercannon"
-	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 5, engineering = 5)
+	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 5, engineering = 7)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 3500, MAT_URANIUM = 2000, MAT_SILVER = 2000, MAT_GOLD = 500)
 	build_path = /obj/item/gun/energy/lasercannon


### PR DESCRIPTION
Dunno why TG disabled this fucking thing. Its huge, its bulky, its situational, it got a low ammo capacity. But it got its uses against certain threats (Blawb, Xenomorphs, Clockwork Cult, Blood Cult Constructs, methed up fucks who run away.) without making it much harder for said antags (heck Xenomorphs become bearable with this fucking thing). Requires now more materials in total (removed diamond Requirement, added Gold, Silver and Uranium.) and more Tech.




:cl: EldritchSigma
add: Adds the Lasercannon back to RnD. No you cant skip interdepartmental cooperation with it. Its tech Origin is not resulting in it giving combat 6. I tried. But its still a usefull gun with a low ammo capacity but high damage. Doesnt fit into backpacks. Kinda like the Para Version. Which is severly underrated.
tweak: Due to increased Syndicate Activity Nanotrasen decided to reinforce their Corporate Security on the station with the Accelerator Laser Cannon, now printable at the RnD Department provided RnD actually works. It is a lethal, low ammo capacity, high damage Energy Weapon. Dont expect to put it into your backpack, the capacitors are fairly huge. 
/:cl:


