### PR TITLE
Fixes cryo pod layer

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -8,7 +8,7 @@
 	anchored = TRUE
 	max_integrity = 350
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 30, acid = 30)
-	layer = ABOVE_WINDOW_LAYER
+	layer = BELOW_OBJ_LAYER
 	state_open = FALSE
 	circuit = /obj/item/circuitboard/machine/cryo_tube
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY


### PR DESCRIPTION
Fixes #300 

![dreamseeker_2017-12-11_21-38-37](https://user-images.githubusercontent.com/26494679/33867700-b670f910-debb-11e7-8d76-1f8ff532501e.png)


The other medbay machines are `layer = 3`, for the record. I can switch it if you want for consitency, but this makes the most sense to me.
🆑 
Cryo pod layer has been adjusted to allow items to show up ontop of it
/ 🆑 