### PR TITLE
ID inside the PDA in the PDA slot now counts towards access

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -19,7 +19,7 @@
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id))
+		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id) || check_access(H.wear_pda))
 			return TRUE
 	else if(ismonkey(M) || isalienadult(M))
 		var/mob/living/carbon/george = M


### PR DESCRIPTION
Not so much a bug fix, but makes behavior identical to Paradise.

Closes #59 

:cl:
ID inside the PDA in the PDA slot now counts towards access
/:cl: