### PR TITLE
Captains Rapier isnt a Vibroblade of death anymore.

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -59,10 +59,9 @@
 	throwforce = 10
 	w_class = WEIGHT_CLASS_BULKY
 	block_chance = 50
-	armour_penetration = 75
-	sharpness = IS_SHARP
+	armour_penetration = 50
 	origin_tech = "combat=5"
-	attack_verb = list("slashed", "cut")
+	attack_verb = list("stabbed", "pierced", "penetrated")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
 


### PR DESCRIPTION
Exactly as it says on the tin. The captains Rapier isnt a fucking Vibroblade anymore capable of dismembering crew with is because dismemberment chance is weird as fuck and defined by IS SHARP and Armor pierce. If is Sharp is removed it shouldnt dismember organic crewmembers (well except they are skeletons for some reason. Or IPCs.). And with shouldnt I mean it doesnt. It doesnt make it completly useless either (as in deadweight that only prevents belts from being worn.).



:cl: EldritchSigma
balance: Captains Rapier isnt a Vibroblade anymore and cannot cut limbs straight off and phase organs out of people.
/:cl:

