### PR TITLE
Duplicate text squashing

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -38,6 +38,18 @@ img.icon {
 	vertical-align: bottom;
 }
 
+.r:before { /* "repeated" badge class for combined messages */
+	content: 'x';
+}
+.r {
+		display: inline;
+		padding: .2em .6em .3em;
+		font-size: 75%;
+		font-weight: 700;
+		line-height: 1;
+		color: #f00;
+}
+
 a {color: #0000ff;}
 a.visited {color: #ff00ff;}
 a:visited {color: #ff00ff;}

--- a/code/modules/goonchat/browserassets/html/browserOutput.html
+++ b/code/modules/goonchat/browserassets/html/browserOutput.html
@@ -35,6 +35,7 @@
 				<a href="#" class="togglePing" id="togglePing"><span>Toggle ping display</span> <i class="icon-circle"></i></a>
 				<a href="#" class="highlightTerm" id="highlightTerm"><span>Highlight string</span> <i class="icon-tag"></i></a>
 				<a href="#" class="saveLog" id="saveLog"><span>Save chat log</span> <i class="icon-save"></i></a>
+				<a href="#" class="subCell toggleCombine" id="toggleCombine"><span>Toggle line combining</span> <i class="icon-filter"></i></a>
 				<a href="#" class="clearMessages" id="clearMessages"><span>Clear all messages</span> <i class="icon-eraser"></i></a>
 			</div>
 		</div>

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -22,7 +22,7 @@ window.onerror = function(msg, url, line, col, error) {
 
 //Globals
 window.status = 'Output';
-var $messages, $subOptions, $subAudio, $selectedSub, $contextMenu, $filterMessages, $last_message;
+var $messages, $subOptions, $contextMenu, $filterMessages, $last_message;
 var opts = {
 	//General
 	'messageCount': 0, //A count...of messages...


### PR DESCRIPTION
:cl: AnturK
add: Repeated, duplicate messages will be squashed into one
/:cl:

This is cool as shit, and helps keep the window clean.

https://github.com/tgstation/tgstation/pull/33605

Examples:

![2017-12-19_17-19-01](https://user-images.githubusercontent.com/26494679/34185257-a704716a-e4e1-11e7-8490-c84e9ddbd168.gif)

![2017-12-19_17-19-54](https://user-images.githubusercontent.com/26494679/34185260-a9c947ea-e4e1-11e7-8f1d-0a6ce798079b.gif)

That being said I am not 100% comfortable with the work I did on the code. I think I got it copied over correctly, but /tg/ has a bunch of new/different stuff in those files that made finding a point of reference to insert it tricky.