### PR TITLE
Adds a shortcut: Alt-click to turn on microwave.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -167,6 +167,10 @@
 	user.set_machine(src)
 	interact(user)
 
+/obj/machinery/microwave/AltClick(mob/user)
+	if(user.canUseTopic(src))
+		cook()
+
 /*******************
 *   Microwave Menu
 ********************/


### PR DESCRIPTION
:cl: AndrewMontagne
tweak: You can now turn on a microwave by alt-clicking it.
/:cl:
