### PR TITLE
Removes the smoke spell from the Chaplain

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -105288,7 +105288,6 @@
 /area/maintenance/port/aft)
 "dXu" = (
 /obj/structure/table/wood/fancy,
-/obj/item/spellbook/oneuse/smoke/lesser,
 /obj/item/nullrod,
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -74806,9 +74806,6 @@
 /area/chapel/office)
 "cMa" = (
 /obj/structure/table/wood,
-/obj/item/spellbook/oneuse/smoke/lesser{
-	name = "mysterious old book of "
-	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
 	name = "flask of holy water";
 	pixel_x = -2;

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -34547,7 +34547,6 @@
 /area/chapel/main)
 "bgC" = (
 /obj/structure/table/wood/fancy,
-/obj/item/spellbook/oneuse/smoke,
 /obj/item/nullrod,
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,


### PR DESCRIPTION
Why did they have this. This was dumb dumb dumb.

:cl: Purpose2
del: Chaplains no longer start with smoke spells on certain stations.
/:cl: