### PR TITLE
Removes Barnyard Curse from Wizard, Adds in Holocarp Fishsticks

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -371,8 +371,8 @@
 
 /datum/spellbook_entry/item/holocarp
 	name = "Holocarp Fishsticks"
-	desc = "A tasty treat of fishsticks. On consumption it will grand the user a holocarp guardian spirit, similar to regular guardian spirits. However it is totally possible to have multiple \
-	multiple stands with this, even in conjunction with a regular guardian spirit from a tarrot deck. You cannot choose the type of holocarp you get. "
+	desc = "A tasty treat of fishsticks. On consumption it will grant the user a holocarp guardian spirit, similar to regular guardian spirits. However it is possible to have multiple \
+	stands with this, even in conjunction with a regular guardian spirit from a tarot deck. You cannot choose the type of holocarp you get."
 	item_path = /obj/item/guardiancreator/carp
 	category = "Assistance"
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -227,10 +227,6 @@
 	cost = 3
 	no_coexistance_typecache = /obj/effect/proc_holder/spell/targeted/infinite_guns/gun
 
-/datum/spellbook_entry/barnyard
-	name = "Barnyard Curse"
-	spell_type = /obj/effect/proc_holder/spell/targeted/barnyardcurse
-
 /datum/spellbook_entry/charge
 	name = "Charge"
 	spell_type = /obj/effect/proc_holder/spell/targeted/charge
@@ -371,6 +367,13 @@
 	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to your body. There are multiple types of guardian available, but all of them will transfer some amount of damage to you. \
 	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/guardiancreator/choose/wizard
+	category = "Assistance"
+
+/datum/spellbook_entry/item/holocarp
+	name = "Holocarp Fishsticks"
+	desc = "A tasty treat of fishsticks. On consumption it will grand the user a holocarp guardian spirit, similar to regular guardian spirits. However it is totally possible to have multiple \
+	multiple stands with this, even in conjunction with a regular guardian spirit from a tarrot deck. You cannot choose the type of holocarp you get. "
+	item_path = /obj/item/guardiancreator/carp
 	category = "Assistance"
 
 /datum/spellbook_entry/item/guardian/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)


### PR DESCRIPTION
Based on TG experience I have had I am only seing Barnyard curse as a huge source of salt which accomplishes nothing for the wizard other than making people cheese him by suicide rushing him. On TG theres no obligation whatsoever to follow objectives and no rules in place for murderboning or being a dick as antag. Here however are and wizards do get indeed objectives other than "Yeah whatever.". On Para the same deal. People wont bother playing against a wizard packing this spells equivalent. Considering this spell is just completly goofy and does nothing whatsoever for the wizard other than being a griff tool and making people salty as fuck theres really no point in this thing, since anyone actually just bypasses it by suddenly knowing the Periodic Table of Elements, going to chemistry and miming them some fluorosulphuric acid (or straight up break in). Sure you cannot wear internals that could kill you... know what also could kill you? A fireball. And thats not even remotely close to round ruining than this shit. Atleast you get to observe the wizard when fireballed jeez. If the wizard wants to do a none lethal approach there are far better spells for that. Like blind. Single Target, makes you blind, means you cannot fight back properly and lasts for quite some time. Or Statue Form. Or all the Tesla Blast type of spells. Or even the transformation staff. All those are crowd control and (mostly) none lethal. And all of them are much more bearable for the crew. If you are command and its a wizard packing this spell you are fucked. Cant cryo. And if you are not captain you cannot even call the shuttle effectivly, forced to spend 30 minutes or more on a round you do not enjoy whatsoever.

Yes I do realize that this PR is very biased. Hence why I would actually like to add something to wizards:

Now Holocarps are interesting: They are like wizards stands. But you can have multiple of these. Up to 5 if you wish so. However you cannot decide what carp you get so you can wind up with 5 protector type guardians if you take 5 fishsticks (it happened on TG already). It is far more fun for ghosts to observe and, atleast in my opinion, alot more fun for the crew to fight against than having a wizard with xray vision barnyard cursing them every now and then.

:cl: EldritchSigma
add: Holocarp Fishsticks for Wizards, tasty sticks that give wizards multiple, albeit random, guardian spirits if multiple are consumed.
del: Removed the fucking barnyard curse that is only used as a griff tool. If you want to go "none lethal" take blind instead or statue form. All much less frustrating than this...
spellcheck: Wizards are less frustrating.
/:cl:

