### PR TITLE
Erradicates last traces of the Barnyard Curse Spell Aviability.

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -857,6 +857,26 @@
 	..()
 	to_chat(user,"<span class='warning'>You're knocked down!</span>")
 	user.Knockdown(40)
+ 
+/obj/item/spellbook/oneuse/barnyard
+	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
+	spellname = "barnyard"
+	icon_state ="bookhorses"
+	desc = "This book is more horse than your mind has room for."
+
+/obj/item/spellbook/oneuse/barnyard/recoil(mob/living/carbon/user)
+	if(ishuman(user))
+		to_chat(user,"<font size='15' color='red'><b>HOR-SIE HAS RISEN</b></font>")
+		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
+		magichead.flags_1 |= NODROP_1		//curses!
+		magichead.flags_inv &= ~HIDEFACE //so you can still see their face
+		magichead.voicechange = 1	//NEEEEIIGHH
+		if(!user.dropItemToGround(user.wear_mask))
+			qdel(user.wear_mask)
+		user.equip_to_slot_if_possible(magichead, slot_wear_mask, 1, 1)
+		qdel(src)
+	else
+		to_chat(user,"<span class='notice'>I say thee neigh</span>") //It still lives here
 
 /obj/item/spellbook/oneuse/charge
 	spell = /obj/effect/proc_holder/spell/targeted/charge

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -857,7 +857,7 @@
 	..()
 	to_chat(user,"<span class='warning'>You're knocked down!</span>")
 	user.Knockdown(40)
- 
+
 /obj/item/spellbook/oneuse/barnyard
 	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
 	spellname = "barnyard"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -858,26 +858,6 @@
 	to_chat(user,"<span class='warning'>You're knocked down!</span>")
 	user.Knockdown(40)
 
-/obj/item/spellbook/oneuse/barnyard
-	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
-	spellname = "barnyard"
-	icon_state ="bookhorses"
-	desc = "This book is more horse than your mind has room for."
-
-/obj/item/spellbook/oneuse/barnyard/recoil(mob/living/carbon/user)
-	if(ishuman(user))
-		to_chat(user,"<font size='15' color='red'><b>HOR-SIE HAS RISEN</b></font>")
-		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
-		magichead.flags_1 |= NODROP_1		//curses!
-		magichead.flags_inv &= ~HIDEFACE //so you can still see their face
-		magichead.voicechange = 1	//NEEEEIIGHH
-		if(!user.dropItemToGround(user.wear_mask))
-			qdel(user.wear_mask)
-		user.equip_to_slot_if_possible(magichead, slot_wear_mask, 1, 1)
-		qdel(src)
-	else
-		to_chat(user,"<span class='notice'>I say thee neigh</span>") //It still lives here
-
 /obj/item/spellbook/oneuse/charge
 	spell = /obj/effect/proc_holder/spell/targeted/charge
 	spellname = "charging"

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -2,7 +2,7 @@
 
 /proc/rightandwrong(summon_type, mob/user, survivor_probability) //0 = Summon Guns, 1 = Summon Magic
 	var/list/gunslist 			= list("taser","gravgun","egun","laser","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","suppressed","cannon","doublebarrel","shotgun","combatshotgun","bulldog","mateba","sabr","crossbow","saw","car","boltaction","speargun","arg","uzi","alienpistol","dragnet","turret","pulsecarbine","decloner","mindflayer","hyperkinetic","advplasmacutter","wormhole","wt550","bulldog","grenadelauncher","goldenrevolver","sniper","medibeam","scatterbeam")
-	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
+	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
 	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos", "necromantic", "bloodcontract")
 
 	if(user) //in this case either someone holding a spellbook or a badmin

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -2,7 +2,7 @@
 
 /proc/rightandwrong(summon_type, mob/user, survivor_probability) //0 = Summon Guns, 1 = Summon Magic
 	var/list/gunslist 			= list("taser","gravgun","egun","laser","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","suppressed","cannon","doublebarrel","shotgun","combatshotgun","bulldog","mateba","sabr","crossbow","saw","car","boltaction","speargun","arg","uzi","alienpistol","dragnet","turret","pulsecarbine","decloner","mindflayer","hyperkinetic","advplasmacutter","wormhole","wt550","bulldog","grenadelauncher","goldenrevolver","sniper","medibeam","scatterbeam")
-	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
+	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
 	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos", "necromantic", "bloodcontract")
 
 	if(user) //in this case either someone holding a spellbook or a badmin
@@ -138,8 +138,6 @@
 					new /obj/item/spellbook/oneuse/forcewall(get_turf(H))
 				if("knock")
 					new /obj/item/spellbook/oneuse/knock(get_turf(H))
-				if("horsemask")
-					new /obj/item/spellbook/oneuse/barnyard(get_turf(H))
 				if("charge")
 					new /obj/item/spellbook/oneuse/charge(get_turf(H))
 				if("summonitem")

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -2,7 +2,7 @@
 
 /proc/rightandwrong(summon_type, mob/user, survivor_probability) //0 = Summon Guns, 1 = Summon Magic
 	var/list/gunslist 			= list("taser","gravgun","egun","laser","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","suppressed","cannon","doublebarrel","shotgun","combatshotgun","bulldog","mateba","sabr","crossbow","saw","car","boltaction","speargun","arg","uzi","alienpistol","dragnet","turret","pulsecarbine","decloner","mindflayer","hyperkinetic","advplasmacutter","wormhole","wt550","bulldog","grenadelauncher","goldenrevolver","sniper","medibeam","scatterbeam")
-	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
+	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor","voodoo", "whistle", "battlemage", "immortality", "ghostsword", "special")
 	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos", "necromantic", "bloodcontract")
 
 	if(user) //in this case either someone holding a spellbook or a badmin


### PR DESCRIPTION
Forgot with my last PR to remove the Horsemask Spell from the chance of being a one time use spellbook.
This PR fixes this. Wizards giving magic wont be able to grant this "spell" to random people on the station. This spell is even worse in the hands of none antag... it leads to alot of greytiding, killing followed by the spell user complaining in Dchat. Speaking from Para Experience.

:cl: EldritchSigma
del: Erradicated any chances to get the horsemask spell on legitimate ways (that is by summon magic). The book is still existant, just should not be obtainable anymore.
/:cl:
