### PR TITLE
Makes Security answer to the Captain

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -116,7 +116,7 @@ Detective
 /datum/job/detective
 	title = "Detective"
 	flag = DETECTIVE
-	department_head = list("Head of Security")
+	department_head = list("the Captain")
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 1
@@ -171,7 +171,7 @@ Security Officer
 	faction = "Station"
 	total_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	supervisors = "the head of security, and the head of your assigned department (if applicable)"
+	supervisors = "the Captain"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
 	exp_requirements = 300


### PR DESCRIPTION
Seeing as there will be no department heads other than the Cap and HoP. it seemed appropriate to make them answer to the former.

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: Changes the Dectective and Sec Officer supervisor to "the Captain" 
/:cl:

[why]: # Clarifies the Captain as the default security overseer