### PR TITLE
Adjusts VTEC to lower movement, needs further balancing probably

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -82,7 +82,7 @@
 		to_chat(usr, "<span class='notice'>There's no room for another VTEC unit!</span>")
 		return
 
-	R.speed = -2 // Gotta go fast.
+	R.speed = -1.25 // Gotta go fast.
 
 	return 1
 


### PR DESCRIPTION
R.speed is the var for speed modifiers apparently. This thing is reponsible why quite a few things are still running on TG movement speed.

I lowered VTECs R.speed in order to push it back in line with the regular movement speed. With this you should be faster using VTEC, just not being insanely fast. Atleast thats the theory. Cause I cannot figure for the live of it out how to take over a mob on a private server.

Referring to #issue435

Actually... it seems fine now... Managed to test it with the changed parameter. Borgs with vtech are now slightly faster than people.

Fixes #438

:cl: EldritchSigma
fix: Fixes Borg VTEC movement speed boost.
/:cl:
