### PR TITLE
Fixes Meth speed so its not that fucking ridicolous.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -173,7 +173,7 @@
 	M.AdjustKnockdown(-40, 0)
 	M.AdjustUnconscious(-40, 0)
 	M.adjustStaminaLoss(-2, 0)
-	M.status_flags |= GOTTAGOREALLYFAST
+	M.status_flags |= GOTTAGOFAST
 	M.Jitter(2)
 	M.adjustBrainLoss(0.25)
 	if(prob(5))


### PR DESCRIPTION
Another simple fix. Meth currently has the "GOTTAGOREALLYFAST" tag that is a straight up multiplier of approx 4 times the movement speed you possess. It is calculated of TG movement speed. The "GOTTAGOFAST" tag is from Ephedrin. It makes you run faster than our movement speed without looking retarded. Its a bit of a "raggy" fix but atleast its somewhere to start so people dont run at incredibly high speed anymore when on meth. That did not make sense in the first place. Meth does make you have a better physical performance, but it does not allow you to run at sonic speed. I do not adorse the usage of drugs I need to say here.



:cl: EldritchSigma
balance: Lowers Meth movement speed buff so its in line with Oracles movement speed.
/:cl:


