### PR TITLE
Sets swarmer speed to Oracle Movement speed.

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -81,7 +81,7 @@
 	attacktext = "shocks"
 	attack_sound = 'sound/effects/empulse.ogg'
 	friendly = "pinches"
-	speed = 0
+	speed = 1
 	faction = list("swarmer")
 	AIStatus = AI_OFF
 	pass_flags = PASSTABLE


### PR DESCRIPTION
Cuts their movement speed in half. They cannot outrun now and have to rely on disablers.

Fixes #436

:cl: EldritchSigma
fix: Swarmer movement speed adjusted to oracle movement speed.
/:cl:
