### PR TITLE
Some IPC fixes

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -351,6 +351,11 @@
 					if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
 						drafted += player.mind
 
+	if(protected_species)
+		for(var/mob/dead/new_player/player in drafted)
+			if(player.client.prefs.pref_species in protected_species)
+				drafted -= player
+
 	if(restricted_jobs)
 		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist
 			for(var/job in restricted_jobs)
@@ -368,6 +373,11 @@
 
 		else												// Not enough scrubs, ABORT ABORT ABORT
 			break
+
+	if(protected_species)
+		for(var/mob/dead/new_player/player in drafted)
+			if(player.client.prefs.pref_species in protected_species)
+				drafted -= player
 
 	if(restricted_jobs)
 		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -314,7 +314,7 @@
 		to_chat(user, "<span class='notice'>You can't modify [M]'s DNA while [M.p_theyre()] dead.</span>")
 		return FALSE
 
-	if(M.has_dna() && !(M.disabilities & NOCLONE))
+	if(M.has_dna() && !(RADIMMUNE in M.dna.species.species_traits) && !(M.disabilities & NOCLONE))
 		M.radiation += rand(20/(damage_coeff  ** 2),50/(damage_coeff  ** 2))
 		var/log_msg = "[key_name(user)] injected [key_name(M)] with the [name]"
 		var/endtime = world.time+duration

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -408,7 +408,7 @@
 			playsound(loc, usesound, 50, 1)
 			if(user == H)
 				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
-				if(!do_mob(user, H, 50))
+				if(!do_mob(user, H, 60))
 					return
 			item_heal_robotic(H, user, 15, 0)
 	else

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -13,6 +13,7 @@
 	var/obj/item/organ/brain/brain = null //The actual brain
 	var/datum/ai_laws/laws = new()
 	var/force_replace_ai_name = FALSE
+	var/silenced = FALSE //if set to TRUE, they can't talk.
 
 /obj/item/device/mmi/update_icon()
 	if(brain)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -224,3 +224,12 @@
 			stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
 			stored_mmi.icon_state = "posibrain-occupied"
 			update_from_mmi()
+
+/obj/item/organ/brain/mmi_holder/emp_act(severity)
+	switch(severity)
+		if(1)
+			owner.adjustBrainLoss(75)
+			to_chat(owner, "<span class='warning'>Alert: Posibrain heavily damaged.</span>")
+		if(2)
+			owner.adjustBrainLoss(25)
+			to_chat(owner, "<span class='warning'>Alert: Posibrain damaged.</span>")

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -28,7 +28,6 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/recharge_message = "<span class='warning'>The positronic brain isn't ready to activate again yet! Give it some time to recharge.</span>"
 	var/list/possible_names //If you leave this blank, it will use the global posibrain names
 	var/picked_name
-	var/silenced = FALSE //if set to TRUE, they can't talk.
 
 /obj/item/device/mmi/posibrain/examine(mob/user)
 	if(..(user, TRUE))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -36,9 +36,10 @@
 
 
 /mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
-	var/spec_return = dna.species.bullet_act(P, src)
-	if(spec_return)
-		return spec_return
+	if(dna && dna.species)
+		var/spec_return = dna.species.bullet_act(P, src)
+		if(spec_return)
+			return spec_return
 
 	if(mind)
 		if(mind.martial_art && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -560,7 +560,7 @@
 			bodyparts_to_add -= "horns"
 
 	if("ipc_screen" in mutant_bodyparts)
-		if(!H.dna.features["ipc_screen"] || H.dna.features["ipc_screen"] == "None" || H.head && (H.head.flags_inv & HIDEFACE) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEEYES)) || !HD)
+		if(!H.dna.features["ipc_screen"] || H.dna.features["ipc_screen"] == "None" || (H.wear_mask && (H.wear_mask.flags_inv & HIDEEYES)) || !HD)
 			bodyparts_to_add -= "ipc_screen"
 
 	if("ipc_antenna" in mutant_bodyparts)

--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -5,10 +5,10 @@
 	heatmod = 3 // Went cheap with Aircooling
 	coldmod = 1.5 // Don't put your computer in the freezer.
 	burnmod = 2 // Wiring doesn't hold up to fire well.
-	brutemod = 1.8 // Thin metal, cheap materials.
+	brutemod = 1.8 // Thin metal, cheap materials. Mind you brute hits have to overcome the inherent armor of BODYPART_ROBOTIC, but if it can, bigger damage.
 	toxmod = 0.5 // Although they can't be poisoned, toxins can damage components
 	clonemod = 0
-	siemens_coeff = 1.5 // Overload!
+	siemens_coeff = 2 // Overload!
 	species_traits = list(NOBREATH, NOBLOOD, RADIMMUNE, VIRUSIMMUNE, NOZOMBIE, EASYDISMEMBER, EASYLIMBATTACHMENT, NOPAIN, NO_BONES, NOTRANSSTING, MUTCOLORS, REVIVESBYHEALING, NOSCAN, NOCHANGELING, NOHUSK, ROBOTIC_LIMBS, NOMOUTH)
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -341,7 +341,7 @@
 
 /mob/living/simple_animal/bot/medbot/proc/assess_patient(mob/living/carbon/C)
 	//Time to see if they need medical help!
-	if(C.stat == DEAD || (C.status_flags & FAKEDEATH))
+	if(C.stat == DEAD || (C.status_flags & FAKEDEATH) || (ROBOTIC_LIMBS in C.dna.species.species_traits))
 		return 0 //welp too late for them!
 
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -341,8 +341,13 @@
 
 /mob/living/simple_animal/bot/medbot/proc/assess_patient(mob/living/carbon/C)
 	//Time to see if they need medical help!
-	if(C.stat == DEAD || (C.status_flags & FAKEDEATH) || (ROBOTIC_LIMBS in C.dna.species.species_traits))
+	if(C.stat == DEAD || (C.status_flags & FAKEDEATH))
 		return 0 //welp too late for them!
+
+	for(var/X in C.bodyparts)
+		var/obj/item/bodypart/part = X
+		if(part.status != BODYPART_ORGANIC)
+			return 0 // No flesh to inject into.
 
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)
 		return 1

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -344,10 +344,13 @@
 	if(C.stat == DEAD || (C.status_flags & FAKEDEATH))
 		return 0 //welp too late for them!
 
+	var/can_inject = FALSE
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/part = X
-		if(part.status != BODYPART_ORGANIC)
-			return 0 // No flesh to inject into.
+		if(part.status == BODYPART_ORGANIC)
+			can_inject = TRUE
+	if(!can_inject)
+		return 0
 
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)
 		return 1

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -207,8 +207,8 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.adjustCloneLoss(rand(2,4) * C.dna.species.clonemod)
-		C.adjustToxLoss(rand(1,2))
+		C.apply_damage(rand(2,4), CLONE)
+		C.apply_damage(rand(1,2), TOX)
 
 		if(prob(10) && C.client)
 			to_chat(C, "<span class='userdanger'>[pick("You can feel your body becoming weak!", \

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -207,7 +207,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.adjustCloneLoss(rand(2,4))
+		C.adjustCloneLoss(rand(2,4) * C.dna.species.clonemod)
 		C.adjustToxLoss(rand(1,2))
 
 		if(prob(10) && C.client)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -521,7 +521,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	if(affecting && affecting.status == BODYPART_ROBOTIC)
 		if(user == H)
 			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")
-			if(!do_mob(user, H, 50))
+			if(!do_mob(user, H, 60))
 				return
 		if(item_heal_robotic(H, user, 0, 15))
 			use(1)


### PR DESCRIPTION
:cl: 
fix: Medibots now ignore IPCs
fix: Slimes now take CLONEMOD into account (so IPCs don't take clone damage)
fix: HIDEFACE on helmets/masks no longer hides monitors
fix: MMIs can talk again, and will not longer cause runtimes
fix: IPCs can no longer be changelings. For real this time.
balance: EMPs now cause brain damage
balance: Getting shocked is 2x instead of just 1.5
balance: Self repair takes one second longer
/:cl:

Fixes https://github.com/OracleStation/OracleStation/issues/508
Fixes https://github.com/OracleStation/OracleStation/issues/512

I'm not 100% about the last one. I'd prefer to make it so you can't channel multiple repairs in parallel, but I couldn't quite square that away.