### PR TITLE
Changes IRC to Discord in Adminwho

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -84,6 +84,6 @@
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
 				msg += "\t[C] is a [C.holder.rank]\n"
-		msg += "<span class='info'>Adminhelps are also sent to IRC. If no admins are available in game adminhelp anyways and an admin on IRC will see it and respond.</span>"
+		msg += "<span class='info'>Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.</span>"
 	to_chat(src, msg)
 


### PR DESCRIPTION
:cl: AffectedArc07
tweak: `Adminwho` no longer says IRC
/:cl:

This server doesnt even have an IRC chat as far as I know, and I dont feel it would be useful when we have a perfectly functioning discord.