### PR TITLE
Unbreaks species locks AGAIN.

### DIFF
--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -112,11 +112,13 @@ GLOBAL_PROTECT(exp_to_update)
 	return return_text
 
 
-/client/proc/get_exp_living()
+/client/proc/get_exp_living(as_text = TRUE)
 	if(!prefs.exp)
 		return "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
-	return get_exp_format(exp_living)
+	if(as_text)
+		return get_exp_format(exp_living)
+	return exp_living
 
 /proc/get_exp_format(expnum)
 	if(expnum > 60)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1691,7 +1691,7 @@
 		return 0
 	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights(R_ADMIN, FALSE, C.mob))
 		return 0
-	var/my_exp = C.calc_exp_type(EXP_TYPE_LIVING) / 60
+	var/my_exp = C.get_exp_living(FALSE) / 60
 	if(my_exp >= required_playtime)
 		return 0
 	else


### PR DESCRIPTION
Because apparently we can't access locked globals even though some other things can I don't understand anymore just merge this and let's be done with it did you know that `Ceiling(5 - (-1/60))` is 6 hours I sure didn't it took me a while to figure out.