### PR TITLE
QOL tweak for Unstable Mutagen in Botany

### DIFF
--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -43,7 +43,7 @@
 	plantname = "Blumpkin Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/blumpkin
 	mutatelist = list()
-	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "nutriment" = 0.2)
+	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "stable_plasma" = 0.1, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/blumpkin


### PR DESCRIPTION
A minor QOL change, since we changed our chem system and all that jazz Unstable Mutagen takes Chlorine, Stable Plasma, and Radium. But in the current /tg/ botany system that we have there is literally no plasma what so ever that can be used. This adds stable plasma to blumpkin production to fix that issue. The current way unless this gets merged is for Botany to harass medical chemists non stop an entire round needing on average 50 units of mutagen per plant, but sometimes up to 150 units depending on RNG.
As such this will make it so they only have to bug a medical chemists a handful of times instead of every 5 minutes or less.

🆑 Xantholne
tweak: Blumpkins now produce Stable Plasma for Unstable Mutagen production.
/🆑 