### PR TITLE
Adds names and jobs to minor announcements

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -49,7 +49,7 @@
 			C.messagetext.Add(text)
 			P.update_icon()
 
-/proc/minor_announce(message, title = "Attention:", alert, mob/living/from)
+/proc/minor_announce(message, title = "Attention:", alert, mob/from)
 	if(!message)
 		return
 
@@ -57,7 +57,7 @@
 		if(!isnewplayer(M) && M.can_hear())
 			var/complete_msg = "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>"
 			if(from)
-				complete_msg += "<span class='alert'>-[from.name] ([from.job])"
+				complete_msg += "<span class='alert'>-[from.name] ([from.job])</span>"
 			to_chat(M, complete_msg)
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -49,13 +49,16 @@
 			C.messagetext.Add(text)
 			P.update_icon()
 
-/proc/minor_announce(message, title = "Attention:", alert)
+/proc/minor_announce(message, title = "Attention:", alert, mob/living/from)
 	if(!message)
 		return
 
 	for(var/mob/M in GLOB.player_list)
 		if(!isnewplayer(M) && M.can_hear())
-			to_chat(M, "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>")
+			var/complete_msg = "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>"
+			if(from)
+				complete_msg += "<span class='alert'>-[from.name] ([from.job])"
+			to_chat(M, complete_msg)
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)
 					SEND_SOUND(M, sound('sound/misc/notice1.ogg'))

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_EMPTY(allConsoles)
 	if(href_list["sendAnnouncement"])
 		if(!announcementConsole)
 			return
-		minor_announce(message, "[department] Announcement:")
+		minor_announce(message, "[department] Announcement:", from = usr)
 		GLOB.news_network.SubmitArticle(message, department, "Station Announcements", null)
 		log_talk(usr,"[key_name(usr)] has made a station announcement: [message]",LOGSAY)
 		message_admins("[key_name_admin(usr)] has made a station announcement.")


### PR DESCRIPTION
Adds names and jobs to minor announcements from desk request consoles.

![dreamseeker_2018-01-30_19-12-16](https://user-images.githubusercontent.com/25027759/35586195-1bba8cf2-05f2-11e8-8120-6202b2915654.png)

🆑 
tweak: adds names and ranks to minor announcements
/🆑 