### PR TITLE
Lowers glide_size to 6 to compensate for the slower movespeed

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -30,7 +30,7 @@
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	var/list/client_mobs_in_contents // This contains all the client mobs within this container
 	var/list/acted_explosions	//for explosion dodging
-	glide_size = 8
+	glide_size = 6
 	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	var/datum/forced_movement/force_moving = null	//handled soley by forced_movement.dm
 	var/floating = FALSE


### PR DESCRIPTION
Title. This makes moving a *lot* smoother than it was previously.

Before
![2018-02-02_10-29-10](https://user-images.githubusercontent.com/6356337/35741103-f21ce4de-0804-11e8-98e0-1d0976cc3b12.gif)

After
![2018-02-02_10-30-04](https://user-images.githubusercontent.com/6356337/35741115-f62a4814-0804-11e8-8875-d68b87f6b319.gif)

:cl: deathride58
tweak: Movement while running is no longer jittery.
/:cl:
