### PR TITLE
Blood fixes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -203,8 +203,7 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 #define BLOOD_FADEOUT_TIME			2
 
 //Bloody shoe blood states
-#define BLOOD_STATE_HUMAN			"blood"
-#define BLOOD_STATE_XENO			"xeno"
+#define BLOOD_STATE_BLOOD			"blood"
 #define BLOOD_STATE_OIL				"oil"
 #define BLOOD_STATE_NOT_BLOODY		"no blood whatsoever"
 

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -8,7 +8,7 @@
 	random_icon_states = list("xfloor1", "xfloor2", "xfloor3", "xfloor4", "xfloor5", "xfloor6", "xfloor7")
 	blood_DNA = list("UNKNOWN DNA" = "X*")
 	bloodiness = MAX_SHOE_BLOODINESS
-	blood_state = BLOOD_STATE_XENO
+	blood_state = BLOOD_STATE_BLOOD
 
 /obj/effect/decal/cleanable/xenoblood/xsplatter
 	random_icon_states = list("xgibbl1", "xgibbl2", "xgibbl3", "xgibbl4", "xgibbl5")
@@ -60,6 +60,9 @@
 	random_icon_states = list("xgiblarvahead", "xgiblarvatorso")
 
 /obj/effect/decal/cleanable/blood/xtracks
-	icon_state = "xtracks"
+	icon_state = "tracks"
 	random_icon_states = null
-	blood_DNA = list("UNKNOWN DNA" = "X*")
+
+/obj/effect/decal/cleanable/blood/xtracks/Initialize()
+	add_blood(list("UNKNOWN DNA" = "X*"))
+	. = ..()

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -5,13 +5,10 @@
 	icon_state = "floor1"
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	blood_DNA = list()
-	blood_state = BLOOD_STATE_HUMAN
+	blood_state = BLOOD_STATE_BLOOD
 	bloodiness = MAX_SHOE_BLOODINESS
 	use_fade = FALSE
-
-/obj/effect/cleanable/blood/Initialize()
-	. = ..()
-	update_icon()
+	color = "#940000"
 
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
 	if (C.blood_DNA)
@@ -38,7 +35,7 @@
 /obj/effect/decal/cleanable/blood/old/Initialize()
 	. = ..()
 	icon_state += "-old" //This IS necessary because the parent /blood type uses icon randomization.
-	add_blood(list(blood_DNA["Non-human DNA"] = "A+"))
+	add_blood(list("Non-human DNA" = "A+"))
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("gibbl1", "gibbl2", "gibbl3", "gibbl4", "gibbl5")
@@ -65,7 +62,7 @@
 	update_icon()
 
 /obj/effect/decal/cleanable/trail_holder/can_bloodcrawl_in()
-	return 1
+	return TRUE
 
 /obj/effect/decal/cleanable/trail_holder/transfer_blood_dna()
 	..()
@@ -140,7 +137,7 @@
 	. = ..()
 	setDir(pick(1,2,4,8))
 	icon_state += "-old"
-	add_blood(list(blood_DNA["Non-human DNA"] = "A+"))
+	add_blood(list("Non-human DNA" = "A+"))
 
 /obj/effect/decal/cleanable/blood/drip
 	name = "drips of blood"
@@ -163,7 +160,7 @@
 	random_icon_states = null
 	var/entered_dirs = 0
 	var/exited_dirs = 0
-	blood_state = BLOOD_STATE_HUMAN //the icon state to load images from
+	blood_state = BLOOD_STATE_BLOOD //the icon state to load images from
 	var/list/shoe_types = list()
 
 /obj/effect/decal/cleanable/blood/footprints/Crossed(atom/movable/O)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -365,7 +365,7 @@ BLIND     // can't see anything
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
 	var/blood_state = BLOOD_STATE_NOT_BLOODY
-	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
+	var/list/bloody_shoes = list(BLOOD_STATE_BLOOD = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
 	var/offset = 0
 	var/equipped_before_drop = FALSE
 	var/last_bloodtype = ""//used to track the last bloodtype to have graced these shoes; makes for better performing footprint shenanigans
@@ -384,7 +384,7 @@ BLIND     // can't see anything
 		if(blood_DNA)
 			bloody = 1
 		else
-			bloody = bloody_shoes[BLOOD_STATE_HUMAN]
+			bloody = bloody_shoes[BLOOD_STATE_BLOOD]
 
 		if(damaged_clothes)
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedshoe")
@@ -417,7 +417,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/shoes/clean_blood()
 	..()
-	bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
+	bloody_shoes = list(BLOOD_STATE_BLOOD = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
 	blood_state = BLOOD_STATE_NOT_BLOODY
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -74,9 +74,6 @@ Difficulty: Hard
 	random_icon_states = list("gib3", "gib5", "gib6")
 	bloodiness = 20
 
-/obj/effect/decal/cleanable/blood/gibs/bubblegum/can_bloodcrawl_in()
-	return TRUE
-
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
 	..()
 	move_to_delay = Clamp((health/maxHealth) * 10, 5, 10)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -496,12 +496,13 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	return FALSE
 
 /proc/bloodtype_to_color(var/type)
-	. = "#DC0000"
+	//all of these strings CANNOT have capitals in them, because that's how BYOND stores their colors and capitals won't work with == checks
+	. = "#dc0000"
 	switch(type)
 		if("F")//Ethari blood; a bit orange
-			. = "#DB3300"
+			. = "#db3300"
 		if("L")//lizard, a bit pink/purple
-			. = "#DB004D"
+			. = "#db004d"
 		if("X*")//xeno blood; not actually used in many spots
-			. = "#00DB21"
+			. = "#88aa00"
 		//add more stuff to the switch if you have more blood colors for different types


### PR DESCRIPTION
:cl: Flatty
fix: Blood always defaults to red; no more white blood
fix: The "leaving" footsteps should now consistently appear on each footstep tile
/:cl:

Also removed xeno blood state because it's only tracked through a different color now.