### PR TITLE
Transforming wigs [WIP]

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1022,8 +1022,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/clothing/head/snowman = 1,
 					/obj/item/clothing/head/cueball = 1,
 					/obj/item/clothing/under/scratch = 1,
-        			/obj/item/clothing/under/sailor = 1,
-        			/obj/item/clothing/ears/headphones = 2)
+					/obj/item/clothing/under/sailor = 1,
+					/obj/item/clothing/ears/headphones = 2,
+					/obj/item/clothing/head/wig = 1)
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1, /obj/item/clothing/head/powdered_wig = 1, /obj/item/gun/magic/wand = 2, /obj/item/clothing/glasses/sunglasses/garb = 2, /obj/item/clothing/glasses/sunglasses/blindfold = 1, /obj/item/clothing/mask/muzzle = 2)
 	premium = list(/obj/item/clothing/suit/pirate/captain = 2, /obj/item/clothing/head/pirate/captain = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/shield/riot/roman = 1, /obj/item/skub = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
@@ -1149,7 +1150,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/obj/item/clothing/head/beanie/striped=1, /obj/item/clothing/head/beanie/stripedred=1, /obj/item/clothing/head/beanie/stripedblue=1, /obj/item/clothing/head/beanie/stripedgreen=1,
 	/obj/item/clothing/suit/jacket/letterman_red=1, /obj/item/clothing/under/victorian_dress=1, /obj/item/clothing/under/victorian_dress/red=1, /obj/item/clothing/under/victorian_suit=1,
 	/obj/item/clothing/under/victorian_suit/redblack=1, /obj/item/clothing/under/victorian_suit/red=1, /obj/item/clothing/suit/tailcoat=1, /obj/item/clothing/suit/victorian_coat=1, /obj/item/clothing/suit/victorian_coat/red=1,
-	/obj/item/clothing/ears/headphones = 10)
+	/obj/item/clothing/ears/headphones = 10, /obj/item/clothing/head/wig = 10)
 	contraband = list(/obj/item/clothing/under/syndicate/tacticool=1, /obj/item/clothing/mask/balaclava=1, /obj/item/clothing/head/ushanka=1, /obj/item/clothing/under/soviet=1, /obj/item/storage/belt/fannypack/black=2, /obj/item/clothing/suit/jacket/letterman_syndie=1, /obj/item/clothing/under/jabroni=1, /obj/item/clothing/suit/vapeshirt=1, /obj/item/clothing/under/geisha=1)
 	premium = list(/obj/item/clothing/under/suit_jacket/checkered=1, /obj/item/clothing/head/mailman=1, /obj/item/clothing/under/rank/mailman=1, /obj/item/clothing/suit/jacket/leather=1, /obj/item/clothing/suit/jacket/leather/overcoat=1, /obj/item/clothing/under/pants/mustangjeans=1, /obj/item/clothing/neck/necklace/dope=3, /obj/item/clothing/suit/jacket/letterman_nanotrasen=1)
 	refill_canister = /obj/item/vending_refill/clothing

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -177,3 +177,51 @@
 /obj/item/clothing/head/cardborg/dropped(mob/living/user)
 	..()
 	user.remove_alt_appearance("standard_borg_disguise")
+
+/obj/item/clothing/head/wig
+	name = "wig"
+	desc = "A bunch of hair that can be styled and change colors.."
+	icon_state = ""
+	item_state = "pwig"
+	flags_inv = HIDEHAIR
+	var/hair_style = "Very Long Hair"
+	var/hair_color = "#000"
+
+/obj/item/clothing/head/wig/Initialize(mapload)
+	hair_style = pick(GLOB.hair_styles_list - "Bald") //Don't want invisible wig
+	hair_color = "#[random_short_color()]"
+	update_icon()
+	. = ..()
+
+/obj/item/clothing/head/wig/update_icon()
+	cut_overlays()
+	var/datum/sprite_accessory/S = GLOB.hair_styles_list[hair_style]
+	if(!S)
+		icon_state = "pwig"
+	else
+		var/mutable_appearance/M = mutable_appearance(S.icon,S.icon_state)
+		M.appearance_flags |= RESET_COLOR
+		M.color = hair_color
+		add_overlay(M)
+
+/obj/item/clothing/head/wig/worn_overlays(isinhands = FALSE, file2use)
+	. = list()
+	if(!isinhands)
+		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hair_style]
+		if(!S)
+			return
+		var/mutable_appearance/M = mutable_appearance(S.icon, S.icon_state,layer = -HAIR_LAYER)
+		M.appearance_flags |= RESET_COLOR
+		M.color = hair_color
+		. += M
+
+/obj/item/clothing/head/wig/attack_self(mob/user)
+	var/hair_style_choice = input(usr, "Which style do you want the wig?", "Wig Style") as null|anything in GLOB.hair_styles_list
+	var/hair_color_choice = input(usr, "Which color do you want the wig to be?", "Color Change") as null|color
+	if(!hair_style)
+		return
+	if(!hair_color)
+		return
+	hair_style = hair_style_choice
+	hair_color = sanitize_hexcolor(hair_color_choice)
+	update_icon()


### PR DESCRIPTION
:cl: AnturK and Ziiro
add: Transforming, recolorable wigs on the autodrobe and clothesmate
/:cl:

Ports and modifies https://github.com/tgstation/tgstation/pull/31304

![2018-02-02_22-20-56](https://user-images.githubusercontent.com/26494679/35763622-6824e042-086d-11e8-997e-276d5f0d23c8.png)

- [ ] Vendor icons are jacked up and I'm too tired to figure out why at the moment.
- [ ]  Needs a funny description either referencing the fact this will be used by species that do not have hair, **or** one referencing the prevalence of baldies on space stations.
- [ ] Color doesn't actually **change** properly. It has color when you pull it out of the vendor, and the style changes properly. Color becomes pure white though.
- [ ] EMP effect that randomly changes its color and style