### PR TITLE
Nerfs Blueshits, reminds shitters to not be shitters

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -424,6 +424,8 @@ SUBSYSTEM_DEF(job)
 	to_chat(M, "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>")
 	if(job.req_admin_notify)
 		to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
+	if(job.special_notice)
+		to_chat(M, "<span class='userdanger'>[job.special_notice]</span>")
 	if(CONFIG_GET(number/minimal_access_threshold))
 		to_chat(M, "<FONT color='blue'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>")
 

--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -15,7 +15,7 @@ Blueshield
 	minimal_player_age = 14
 	exp_requirements = 600 //10 hours
 	exp_type = EXP_TYPE_CREW
-	special_notice = "You are not a security officer. Do not do their job."
+	special_notice = "You are a bodyguard for heads of staff. You are not a security officer. Do not do security's job."
 
 	outfit = /datum/outfit/job/blueshield
 

--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -3,27 +3,30 @@ Blueshield
 */
 
 /datum/job/blueshield
-  title = "Blueshield"
-  flag = BLUESHIELD
-  department_flag = CIVILIAN
-  faction = "Station"
-  total_positions = 1
-  spawn_positions = 1
-  supervisors = "captain and command personnel"
-  selection_color = "#ddddff"
-  req_admin_notify = 1
-  minimal_player_age = 14
+	title = "Blueshield"
+	flag = BLUESHIELD
+	department_flag = CIVILIAN
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "captain and command personnel"
+	selection_color = "#ddddff"
+	req_admin_notify = 1
+	minimal_player_age = 14
+	exp_requirements = 600 //10 hours
+	exp_type = EXP_TYPE_CREW
+	special_notice = "You are not a security officer. Do not do their job."
 
-  outfit = /datum/outfit/job/blueshield
+	outfit = /datum/outfit/job/blueshield
 
-  access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_WEAPONS,
-			            ACCESS_MEDICAL, ACCESS_ENGINE, ACCESS_CHANGE_IDS, ACCESS_AI_UPLOAD, ACCESS_EVA, ACCESS_HEADS,
+	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_WEAPONS,
+			            ACCESS_MEDICAL, ACCESS_ENGINE, ACCESS_AI_UPLOAD, ACCESS_EVA,
 			            ACCESS_ALL_PERSONAL_LOCKERS, ACCESS_MAINT_TUNNELS, ACCESS_BAR, ACCESS_JANITOR, ACCESS_CONSTRUCTION, ACCESS_MORGUE,
 			            ACCESS_CREMATORIUM, ACCESS_KITCHEN, ACCESS_CARGO, ACCESS_CARGO_BOT, ACCESS_MAILSORTING, ACCESS_QM, ACCESS_HYDROPONICS, ACCESS_LAWYER,
 			            ACCESS_THEATRE, ACCESS_CHAPEL_OFFICE, ACCESS_LIBRARY, ACCESS_RESEARCH, ACCESS_MINING, ACCESS_HEADS_VAULT, ACCESS_MINING_STATION,
-			            ACCESS_HOP, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_MINERAL_STOREROOM, ACCESS_BLUESHIELD)
-  minimal_access = list(ACCESS_FORENSICS_LOCKERS, ACCESS_SEC_DOORS, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_MAINT_TUNNELS,
-                  ACCESS_RESEARCH, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_HEADS, ACCESS_BLUESHIELD, ACCESS_WEAPONS)
+			            ACCESS_HOP, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_MINERAL_STOREROOM, ACCESS_BLUESHIELD, ACCESS_CAPTAIN, ACCESS_RD, ACCESS_HOS, ACCESS_CMO, ACCESS_CE)
+	minimal_access = list(ACCESS_FORENSICS_LOCKERS, ACCESS_SEC_DOORS, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_MAINT_TUNNELS,
+                  ACCESS_RESEARCH, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_BLUESHIELD, ACCESS_QM, ACCESS_HOP, ACCESS_WEAPONS, ACCESS_CAPTAIN, ACCESS_RD, ACCESS_HOS, ACCESS_CMO, ACCESS_CE)
 
 /datum/outfit/job/blueshield
   name = "Blueshield"

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -69,6 +69,7 @@ Head of Personnel
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
+	special_notice = "You are not a security officer. Do not do their job."
 
 	outfit = /datum/outfit/job/hop
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -72,6 +72,7 @@ Mime
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	special_notice = "There is a difference between harmless pranks and griefing. Know it."
 
 	outfit = /datum/outfit/job/mime
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -11,6 +11,7 @@ Clown
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	special_notice = "There is a difference between harmless pranks and griefing. Know it."
 
 	outfit = /datum/outfit/job/clown
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -48,6 +48,9 @@
 	var/exp_type = ""
 	var/exp_type_department = ""
 
+	//A special, very large and noticeable message for certain roles reminding them of something important. Ex: "Blueshields are not security"
+	var/special_notice = ""
+
 //Only override this proc
 //H is usually a human unless an /equip override transformed it
 /datum/job/proc/after_spawn(mob/living/H, mob/M)

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -126,6 +126,7 @@ Detective
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	special_notice = "You are not a security officer. Do not do their job."
 
 	outfit = /datum/outfit/job/detective
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -126,7 +126,7 @@ Detective
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	special_notice = "You are not a security officer. Do not do their job."
+	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance."
 
 	outfit = /datum/outfit/job/detective
 


### PR DESCRIPTION
Fixes #529 

:cl: ike709
add: Some roles now have reminders of what not to do.
balance: Blueshields are now timelocked at ten hours as crew.
balance: Blueshields can no longer use identification consoles to alter IDs.
/:cl:

A role that often wanders the station as an all access rambo is no bueno.

Also, no clue what the hell is wrong with blueshield.dm formatting, but good luck playing spot the difference.

Example of a special notice (EDIT: Different words in the latest version):
![image](https://user-images.githubusercontent.com/5714543/35774265-7e2a1548-092f-11e8-91e7-2628b287fbd1.png)
