### PR TITLE
Lets IPCs drink.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -826,7 +826,7 @@
 	.["Modify organs"] = "?_src_=vars;[HrefToken()];editorgans=[REF(src)]"
 	.["Hallucinate"] = "?_src_=vars;[HrefToken()];hallucinate=[REF(src)]"
 
-/mob/living/carbon/has_mouth()
+/mob/living/carbon/has_mouth(just_sipping = FALSE)
 	for(var/obj/item/bodypart/head/head in bodyparts)
-		if(head.mouth)
+		if(head.mouth || just_sipping)//if we're just sipping any orifice will do
 			return TRUE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -11,6 +11,7 @@
 	var/spawned_disease = null
 	var/disease_amount = 20
 	var/spillable = 0
+	var/you_drink_from_this = FALSE
 
 /obj/item/reagent_containers/Initialize(mapload, vol)
 	. = ..()
@@ -69,7 +70,7 @@
 		var/who = (isnull(user) || eater == user) ? "your" : "[eater.p_their()]"
 		to_chat(user, "<span class='warning'>You have to remove [who] [covered] first!</span>")
 		return 0
-	if(!eater.has_mouth())
+	if(!eater.has_mouth(you_drink_from_this))
 		if(eater == user)
 			to_chat(eater, "<span class='warning'>You have no mouth, and cannot eat.</span>")
 		else

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -6,6 +6,7 @@
 	container_type = OPENCONTAINER_1
 	spillable = 1
 	resistance_flags = ACID_PROOF
+	you_drink_from_this = TRUE
 
 
 /obj/item/reagent_containers/glass/attack(mob/M, mob/user, obj/target)


### PR DESCRIPTION
Because you can't deconvert IPC cultists and there are tons of other, more troublesome instances of this being a bad thing.

This actually lets all species drink as long as they have heads, but the only instance of this being impactful is abductors, who can now down a few shots of whiskey before getting themselves killed.

"But Flattest the Ayys will powergame with meth now and all that!", you say.

Well, they could've already used patches or syringes or divine intervention if they wanted to powergame with chems; this changes nothing.

They still can't eat solid food, just drink reagents from glasses, bottles and beakers.

:cl: Flatty
tweak: IPCs can drink stuff now. Go get smashed, beep boop.
/:cl: