### PR TITLE
Radio messages show the speaker's job

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -74,7 +74,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	return ""
+	var/speakerJob = speaker.GetJob()
+	return "[ speakerJob ? " (" +  speakerJob + ")" : ""]"
 
 /atom/movable/proc/say_mod(input, message_mode)
 	var/ending = copytext(input, length(input))

--- a/code/modules/mob/say_readme.dm
+++ b/code/modules/mob/say_readme.dm
@@ -93,7 +93,7 @@ global procs
 		Composes the href tags used by the AI for tracking. Returns "" for all mobs except AIs.
 
 	compose_job(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs.
+		Composes the job and the end tag for tracking hrefs. Returns the job title string.
 
 	hivecheck()
 		Returns 1 if the mob can hear and talk in the alien hivemind.


### PR DESCRIPTION
:cl: ike709
add: Radio messages show the speaker's job
/:cl:

Literally the best NTSL script. Shows `(Unknown)` if job is unknown, and nothing if it is null for some reason.

![image](https://user-images.githubusercontent.com/5714543/35784008-73eb5422-09d7-11e8-8d2d-c9c30a080c58.png)