### PR TITLE
Disables beach bum biome from spawning

### DIFF
--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -5,7 +5,7 @@
 
 ##BIODOMES
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
 


### PR DESCRIPTION
:cl: 
tweak: beach bum biome now on the lavaland blacklist
/:cl:

Cleaner do-over of https://github.com/OracleStation/OracleStation/pull/221

This probably won't work because it's a config, but, may as well make the opinion known.

This is the worst lavaland ruin.
* It has no interesting items for miners to seek it out for
* The denizens have no meaningful ways to interact with the station due to language barriers
* They do not even have the tools to reach the station
* They have no goals (ashwalkers), or progression(golems)