### PR TITLE
Emagged Airlocks Are Easier To Deconstruct

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1248,7 +1248,7 @@
 		charge.forceMove(get_turf(user))
 		charge = null
 		return
-	if( beingcrowbarred && (density && welded && !operating && src.panel_open && (!hasPower()) && !src.locked) )
+	if(beingcrowbarred && panel_open && (emagged || (density && welded && !operating && !hasPower() && !locked)))
 		playsound(src.loc, I.usesound, 100, 1)
 		user.visible_message("[user] removes the electronics from the airlock assembly.", \
 							 "<span class='notice'>You start to remove electronics from the airlock assembly...</span>")


### PR DESCRIPTION
You can emag many airlocks very quickly and it's a lot of work waiting first for a minute to elapse (so the airlock regains power), fiddling with the wires and finally welding + crowbarring. I know you can use an RCD but it should not be this tedious without one.
Changed it to be like Baycode servers where all you need to do is crowbar the airlock when the panel is open to deconstruct it if it's emagged

🆑
tweak: Emagged airlocks can now be deconstructed simply by crowbarring when the panel is open
/🆑