### PR TITLE
Inform connected admins of freezing

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -488,12 +488,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		M.adminfreezeoverlay = new()
 		M.add_overlay(M.adminfreezeoverlay)
 		log_admin("[key_name(usr)] froze [key_name(M)]!")
+		message_admins("[key_name(usr)] froze [key_name(M)]!")
 		to_chat(M, "<span class='userdanger'>You have been frozen by Administrator [usr.key]!</span>")
 	else
 		M.SetSleeping(M.adminfrozen)//set it to what it was before freezing or just 1/10th of a second if it was nothing
 		M.adminfrozen = 0
 		M.cut_overlay(M.adminfreezeoverlay)
 		log_admin("[key_name(usr)] unfroze [key_name(M)].")
+		message_admins("[key_name(usr)] unfroze [key_name(M)].")
 		to_chat(M, "<span class='userdanger'>You have been unfrozen by Administrator [usr.key]!</span>")
 
 /client/proc/cmd_admin_create_centcom_report()


### PR DESCRIPTION
No changelog needed, its just for the mins.

This tells connected admins that an admin has frozen/unfrozen someone, which was missed from the original PR, which only logged the interaction.