### PR TITLE
IPCs now properly clear oxydamage and breathloss

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -158,6 +158,7 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	H.visible_message("<span class='notice'>[H] unplugs from the [A].</span>", "<span class='notice'>You unplug from the [A].</span>")
 
 /datum/species/ipc/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.health <= HEALTH_THRESHOLD_CRIT && H.stat != DEAD) // So they die eventually instead of being stuck in crit limbo.
 		H.adjustFireLoss(6) // After bodypart_robotic resistance this is ~2/second
 		if(prob(5))


### PR DESCRIPTION
:cl:
fix: IPCs now properly clear oxydamage and breathloss
/:cl:

Fixes https://github.com/OracleStation/OracleStation/issues/577

This also might've been blocking some other `spec_life` behavior, but seeing as we've had nothing else reported, I'm not sure...