### PR TITLE
Prevents server crashing via mob spam

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -144,7 +144,6 @@
 #define GALOSHES_DONT_HELP 4
 #define SLIDE_ICE 8
 
-#define MAX_CHICKENS 50
 
 #define UNHEALING_EAR_DAMAGE 100
 
@@ -168,3 +167,9 @@
 //Taste defines
 #define NO_TASTE_SENSITIVITY -1
 #define DEFAULT_TASTE_SENSITIVITY 15
+
+// Monkeycube/chicken/slime spam prevention
+// This is the maximum number of each mob type that can exist at once
+#define MAX_CUBE_MONKEYS 5 //placeholder //Only applies to monkeys spawned via monkeycube, since monkeys can't normally reproduce
+#define MAX_CHICKENS 5 //placeholder
+#define MAX_SLIMES 5 //placeholder

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -167,9 +167,3 @@
 //Taste defines
 #define NO_TASTE_SENSITIVITY -1
 #define DEFAULT_TASTE_SENSITIVITY 15
-
-// Monkeycube/chicken/slime spam prevention
-// This is the maximum number of each mob type that can exist at once
-#define MAX_CUBE_MONKEYS 5 //placeholder //Only applies to monkeys spawned via monkeycube, since monkeys can't normally reproduce
-#define MAX_CHICKENS 5 //placeholder
-#define MAX_SLIMES 5 //placeholder

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -16,3 +16,8 @@ GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a perce
 GLOBAL_LIST_EMPTY(powernets)
 
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)	//BSA unlocked by head ID swipes
+
+// Monkeycube/chicken/slime spam prevention
+GLOBAL_VAR_INIT(total_cube_monkeys, 0)
+GLOBAL_VAR_INIT(total_chickens, 0)
+GLOBAL_VAR_INIT(total_slimes, 0)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -265,3 +265,11 @@ CONFIG_DEF(number/bombcap)
 CONFIG_DEF(flag/shutdown_for_update)			// Shuts down the world instead of reboot
 CONFIG_DEF(string/update_version_string_uri)	// Location of the hash to compare against COMMIT_HASH
 	value = "http://s3.us-east-1.oraclestation.com/master/latest/COMMIT_HASH"
+
+//Mob spam prevention
+CONFIG_DEF(number/max_cube_monkeys)
+	value = 100
+CONFIG_DEF(number/max_chickens)
+	value = 100
+CONFIG_DEF(number/max_slimes)
+	value = 100

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -184,7 +184,7 @@
 	foodtype = MEAT | SUGAR
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Expand()
-	if(GLOB.total_cube_monkeys >= MAX_CUBE_MONKEYS)
+	if(GLOB.total_cube_monkeys >= CONFIG_GET(number/max_cube_monkeys))
 		visible_message("<span class='warning'>[src] refuses to expand!</span>")
 		return
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -184,9 +184,13 @@
 	foodtype = MEAT | SUGAR
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Expand()
+	if(GLOB.total_cube_monkeys >= MAX_CUBE_MONKEYS)
+		visible_message("<span class='warning'>[src] refuses to expand!</span>")
+		return
+
 	visible_message("<span class='notice'>[src] expands!</span>")
 	var/mob/spammer = get_mob_by_key(src.fingerprintslast)
-	var/mob/living/carbon/monkey/bananas = new(get_turf(src))
+	var/mob/living/carbon/monkey/cube/bananas = new(get_turf(src))
 	bananas.log_message("Spawned via [src] at [COORD(src)], Last attached mob: [key_name(spammer)].", INDIVIDUAL_ATTACK_LOG)
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -63,7 +63,7 @@
 
 	if (bodytemperature < 283.222)
 		. += (283.222 - bodytemperature) / 10 * 1.75
-		
+
 	var/static/config_monkey_delay
 	if(isnull(config_monkey_delay))
 		config_monkey_delay = CONFIG_GET(number/monkey_delay)
@@ -157,3 +157,19 @@
 		var/obj/item/clothing/head/helmet/justice/escape/helmet = new(src)
 		equip_to_slot_or_del(helmet,slot_head)
 		helmet.attack_self(src) // todo encapsulate toggle
+
+
+//Special monkeycube subtype to track the number of them and prevent spam
+/mob/living/carbon/monkey/cube/Initialize()
+	. = ..()
+	GLOB.total_cube_monkeys++
+
+/mob/living/carbon/monkey/cube/death(gibbed)
+	GLOB.total_cube_monkeys--
+	..(gibbed)
+
+//In case admins delete them before they die
+/mob/living/carbon/monkey/cube/Destroy()
+	if(stat != DEAD)
+		GLOB.total_cube_monkeys--
+	return ..()

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -166,7 +166,7 @@
 
 /mob/living/carbon/monkey/cube/death(gibbed)
 	GLOB.total_cube_monkeys--
-	..(gibbed)
+	..()
 
 //In case admins delete them before they die
 /mob/living/carbon/monkey/cube/Destroy()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -295,7 +295,7 @@
 	. =..()
 	if(!.)
 		return
-	if((!stat && prob(3) && eggsleft > 0) && egg_type && GLOB.total_chickens < MAX_CHICKENS)
+	if((!stat && prob(3) && eggsleft > 0) && egg_type && GLOB.total_chickens < CONFIG_GET(number/max_chickens))
 		visible_message("[src] [pick(layMessage)]")
 		eggsleft--
 		var/obj/item/E = new egg_type(get_turf(src))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -211,7 +211,7 @@
 
 /mob/living/simple_animal/chick/death(gibbed)
 	GLOB.total_chickens--
-	..(gibbed)
+	..()
 
 /mob/living/simple_animal/chick/Destroy()
 	if(stat != DEAD)
@@ -270,7 +270,7 @@
 
 /mob/living/simple_animal/chicken/death(gibbed)
 	GLOB.total_chickens--
-	..(gibbed)
+	..()
 
 /mob/living/simple_animal/chicken/Destroy()
 	if(stat != DEAD)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -197,6 +197,7 @@
 	. = ..()
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+	GLOB.total_chickens++
 
 /mob/living/simple_animal/chick/Life()
 	. =..()
@@ -207,6 +208,15 @@
 		if(amount_grown >= 100)
 			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
+
+/mob/living/simple_animal/chick/death(gibbed)
+	GLOB.total_chickens--
+	..(gibbed)
+
+/mob/living/simple_animal/chick/Destroy()
+	if(stat != DEAD)
+		GLOB.total_chickens--
+	return ..()
 
 /mob/living/simple_animal/chick/holo/Life()
 	..()
@@ -246,7 +256,6 @@
 	var/list/layMessage = list("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")
 	var/list/validColors = list("brown","black","white")
 	gold_core_spawnable = 2
-	var/static/chicken_count = 0
 
 /mob/living/simple_animal/chicken/Initialize()
 	. = ..()
@@ -257,10 +266,15 @@
 	icon_dead = "[icon_prefix]_[body_color]_dead"
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
-	++chicken_count
+	GLOB.total_chickens++
+
+/mob/living/simple_animal/chicken/death(gibbed)
+	GLOB.total_chickens--
+	..(gibbed)
 
 /mob/living/simple_animal/chicken/Destroy()
-	--chicken_count
+	if(stat != DEAD)
+		GLOB.total_chickens--
 	return ..()
 
 /mob/living/simple_animal/chicken/attackby(obj/item/O, mob/user, params)
@@ -281,14 +295,14 @@
 	. =..()
 	if(!.)
 		return
-	if((!stat && prob(3) && eggsleft > 0) && egg_type)
+	if((!stat && prob(3) && eggsleft > 0) && egg_type && GLOB.total_chickens < MAX_CHICKENS)
 		visible_message("[src] [pick(layMessage)]")
 		eggsleft--
 		var/obj/item/E = new egg_type(get_turf(src))
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
 		if(eggsFertile)
-			if(chicken_count < MAX_CHICKENS && prob(25))
+			if(prob(25))
 				START_PROCESSING(SSobj, E)
 
 /obj/item/reagent_containers/food/snacks/egg/var/amount_grown = 0

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -21,6 +21,7 @@
 	if(buckled)
 		Feedstop(silent = 1) //releases ourselves from the mob we fed on.
 
+	GLOB.total_slimes--
 	stat = DEAD
 	cut_overlays()
 
@@ -40,4 +41,6 @@
 	for(var/obj/machinery/computer/camera_advanced/xenobio/X in GLOB.machines)
 		if(src in X.stored_slimes)
 			X.stored_slimes -= src
+	if(stat != DEAD)
+		GLOB.total_slimes--
 	return ..()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -145,7 +145,7 @@
 			if(stat)
 				to_chat(src, "<i>I must be conscious to do this...</i>")
 				return
-			if(GLOB.total_slimes >= MAX_SLIMES)
+			if(GLOB.total_slimes >= CONFIG_GET(number/max_slimes))
 				to_chat(src, "<i>There are too many of us...</i>")
 				return
 			var/list/babies = list()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -145,7 +145,9 @@
 			if(stat)
 				to_chat(src, "<i>I must be conscious to do this...</i>")
 				return
-
+			if(GLOB.total_slimes >= MAX_SLIMES)
+				to_chat(src, "<i>There are too many of us...</i>")
+				return
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -77,6 +77,7 @@
 	"cerulean", "sepia", "black", "pyrite")
 
 /mob/living/simple_animal/slime/Initialize(mapload, new_colour="grey", new_is_adult=FALSE)
+	GLOB.total_slimes++
 	var/datum/action/innate/slime/feed/F = new
 	F.Grant(src)
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -499,3 +499,8 @@ MICE_ROUNDSTART 10
 ## Shutdown the world instead of rebooting
 #SHUTDOWN_FOR_UPDATE
 #UPDATE_VERSION_STRING_URI http://s3.us-east-1.oraclestation.com/master/latest/COMMIT_HASH
+
+## Mob spam prevention. The number of each mobtype that can be alive at once. Stops people from crashing the server with chickens/monkeycubes/slimes. Altering these values is recommended based on server hardware.
+MAX_CUBE_MONKEYS 100
+MAX_CHICKENS 100
+MAX_SLIMES 100


### PR DESCRIPTION
:cl: ike709
tweak: There is now a cap on the number of chickens, slimes, and monkeycube monkeys that can be alive at once. No more crashing the server with 200 monkeys/chickens.
/:cl:

Tested and working. ~~Current limits are placeholder for ease of testing and because I don't know what the server can handle.~~

~~I need a maintainer to suggest what good limits for each are.~~

~~DO NOT MERGE UNTIL PLACEHOLDER LIMITS ARE REPLACED!~~

Let me know if there's any other self-reproducing or easily spammable mobs I need to apply a cap to.

EDIT: Value is now a config option. Note that this PR alters the config.