### PR TITLE
Makes runtimes for callbacks on QDEL'd objects show the type.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -456,7 +456,7 @@ SUBSYSTEM_DEF(timer)
 
 	//alot of things add short timers on themselves in their destroy, we ignore those cases
 	if (wait >= 1 && callback && callback.object && callback.object != GLOBAL_PROC && QDELETED(callback.object))
-		stack_trace("addtimer called with a callback assigned to a qdeleted object")
+		stack_trace("addtimer called with a callback assigned to a qdeleted object [callback.object_path]")
 
 	wait = max(wait, 0)
 

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -48,10 +48,13 @@
 	var/datum/object = GLOBAL_PROC
 	var/delegate
 	var/list/arguments
+	var/object_path = ""
 
 /datum/callback/New(thingtocall, proctocall, ...)
 	if (thingtocall)
 		object = thingtocall
+		if(thingtocall != GLOBAL_PROC)
+			object_path = "[object.type]"
 	delegate = proctocall
 	if (length(args) > 2)
 		arguments = args.Copy(3)


### PR DESCRIPTION
Because holy heck I can't track any of that crap down.