### PR TITLE
more accurate timer on species locks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	datspecies += "<a href='?_src_=prefs;preference=job;task=close'>Done</a><BR>"
 	var/required = S.required_playtime_remaining(parent)
 	if(required)
-		datspecies += "<span class='warning'><font color='red'>Need [Ceiling(required)] hours to unlock!</font></span>"
+		datspecies += "<span class='warning'><font color='red'>[required] more to unlock!</font></span>"
 	datspecies += "</center></th></tr></table></div>"
 
 	user << browse(null, "window=preferences")

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -113,9 +113,11 @@ GLOBAL_PROTECT(exp_to_update)
 
 
 /client/proc/get_exp_living(as_text = TRUE)
-	if(!prefs.exp)
+	if(!prefs.exp && as_text)
 		return "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
+	if(!exp_living)
+		exp_living = 0
 	if(as_text)
 		return get_exp_format(exp_living)
 	return exp_living

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1691,11 +1691,11 @@
 		return 0
 	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights(R_ADMIN, FALSE, C.mob))
 		return 0
-	var/my_exp = C.get_exp_living(FALSE) / 60
-	if(my_exp >= required_playtime)
+	var/my_exp = C.get_exp_living(FALSE)
+	if(my_exp / 60 >= required_playtime)
 		return 0
 	else
-		return (required_playtime - my_exp)
+		return (get_exp_format(required_playtime * 60 - my_exp))
 
 #undef HEAT_DAMAGE_LEVEL_1
 #undef HEAT_DAMAGE_LEVEL_2


### PR DESCRIPTION
:cl: Flatty
tweak: the species selection menu now gives a more accurate amount of time needed to play that species
/:cl:

Because people are bad at telling time and good at telling Maintainers they're wrong.

\>:C

No mechanical changes, just now you get the minutes left to unlock a species as well.