### PR TITLE
Buffs cursed heart

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -567,6 +567,7 @@
 	heal_brute = 25
 	heal_burn = 25
 	heal_oxy = 25
+	heal_tox = 25
 
 //Warp Whistle: Provides uncontrolled long distance teleportation.
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -81,9 +81,10 @@
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
-	var/heal_brute = 0
-	var/heal_burn = 0
-	var/heal_oxy = 0
+	var/heal_brute = 5
+	var/heal_burn = 5
+	var/heal_oxy = 5
+	var/heal_tox = 5
 
 
 /obj/item/organ/heart/cursed/attack(mob/living/carbon/human/H, mob/living/carbon/human/user, obj/target)
@@ -138,6 +139,7 @@
 				H.adjustBruteLoss(-cursed_heart.heal_brute)
 				H.adjustFireLoss(-cursed_heart.heal_burn)
 				H.adjustOxyLoss(-cursed_heart.heal_oxy)
+				H.adjustToxLoss(-cursed_heart.heal_tox)
 
 
 /datum/client_colour/cursed_heart_blood

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -81,10 +81,10 @@
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
-	var/heal_brute = 5
-	var/heal_burn = 5
-	var/heal_oxy = 5
-	var/heal_tox = 5
+	var/heal_brute = 0
+	var/heal_burn = 0
+	var/heal_oxy = 0
+	var/heal_tox = 0
 
 
 /obj/item/organ/heart/cursed/attack(mob/living/carbon/human/H, mob/living/carbon/human/user, obj/target)


### PR DESCRIPTION
:cl:
balance: Basic cursed heart now heals 5 damage of all types when pumped
balance: Wizard Cursed heart now also heals 25 toxin damage per pump
/:cl:

[why]: As is, finding the basic cursed heart in a necropolis chest is dumb because it's literally a useless item. (It healed nothing. It just requires you to pump manually. Why would anyone use this?). I feel like there should be some kind of reward for having the APM to use this annoying piece of shit.
