### PR TITLE
Status panel shows playercount

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -576,6 +576,7 @@
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
 		stat(null, "Station Time: [worldtime2text()]")
 		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
+		stat(null, "Playing/Connected: [get_active_player_count(0,0,0)]/[GLOB.clients.len]")
 		if(SSshuttle.emergency)
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)


### PR DESCRIPTION
:cl: ike709
add: The Status panel will now show the playing/connected players.
/:cl:

I'm tired of clicking Who literally every round.

`get_active_player_count` includes everybody regardless of if they're afk, alive, or human. Ghosts are counted but only if they didn't hit Observe in the lobby. People chilling in the lobby are not counted, IIRC.