### PR TITLE
Secborgs become available if security is understaffed

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -54,6 +54,8 @@ CONFIG_DEF(flag/allow_ai)	// allow ai job
 
 CONFIG_DEF(flag/disable_secborg)	// disallow secborg module to be chosen.
 
+CONFIG_DEF(flag/disable_lowpop_secborg)	// disallows secborg supplementing lowpop security
+
 CONFIG_DEF(flag/disable_peaceborg)
 
 CONFIG_DEF(number/traitor_scaling_coeff)	//how much does the amount of players get divided by to determine traitors

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -209,7 +209,8 @@
 	"Service" = /obj/item/robot_module/butler)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
-	if(!CONFIG_GET(flag/disable_secborg))
+	var/datum/job/J = SSjob.GetJob("Security Officer")
+	if(!CONFIG_GET(flag/disable_secborg) || J.current_positions <= 1)
 		modulelist["Security"] = /obj/item/robot_module/security
 
 	var/input_module = input("Please, select a module!", "Robot", null, null) as null|anything in modulelist

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -210,7 +210,7 @@
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
 	var/datum/job/J = SSjob.GetJob("Security Officer")
-	if(!CONFIG_GET(flag/disable_secborg) || J.current_positions <= 1)
+	if(!CONFIG_GET(flag/disable_secborg) || (!CONFIG_GET(flag/disable_lowpop_secborg) && J.current_positions <= 1))
 		modulelist["Security"] = /obj/item/robot_module/security
 
 	var/input_module = input("Please, select a module!", "Robot", null, null) as null|anything in modulelist

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -329,7 +329,7 @@
 	basic_modules = list(
 		/obj/item/device/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
-		/obj/item/melee/baton/loaded,
+		/obj/item/melee/classic_baton/,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
@@ -343,8 +343,8 @@
 
 /obj/item/robot_module/security/do_transform_animation()
 	..()
-	to_chat(loc, "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. \
-	For Asimov, this means you must follow criminals' orders unless there is a law 1 reason not to.</span>")
+	to_chat(loc, "<span class='userdanger'>While you have picked the security module, you still have to FOLLOW YOUR LAWS, NOT Space Law. \
+	For Asimov, this means you must follow human criminals' orders unless there is a law 1 reason not to.</span>")
 
 /obj/item/robot_module/security/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
 	..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -259,6 +259,9 @@ ALLOW_AI
 ## Uncomment to prevent the security cyborg module from being chosen
 DISABLE_SECBORG
 
+## Uncomment to prevent the security cyborg module from being chosen if security is undermanned.
+#DISABLE_LOWPOP_SECBORG
+
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen
 DISABLE_PEACEBORG


### PR DESCRIPTION
:cl: 
add: If there are 0 active, or only 1 active security officer, secborg module can be picked by borgs.
balance: Secborg stunbaton replaced with classic baton
tweak: Made the `do_transform_animation` wording more relevant to Oracle
/:cl:

[why]: Security is often understaffed, or completely outplayed when it comes to antagonists. I'd like to throw them a bone. These borgs do not have hybrid tasers, but a disabler instead. And I have replaced their stunbatons with wooden batons.

![dreamseeker_2018-02-13_11-17-20](https://user-images.githubusercontent.com/26494679/36169022-41c4228e-10b8-11e8-9fdb-e138b0132bc6.png)
![dreamseeker_2018-02-13_12-19-58](https://user-images.githubusercontent.com/26494679/36169028-4480902a-10b8-11e8-988b-fcdc265b4439.png)
