### PR TITLE
Makes mentors show in Adminwho instead of Who

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -89,6 +89,6 @@
 		for(var/client/C in sortList(GLOB.clients))
 			var/mentor = GLOB.mentor_datums[C.ckey]
 			if(mentor)
-				msg += "<span class='info'>\t[C.key]</span> - Mentor \n"
+				msg += "<span>\t[C.key]</span> is a Mentor \n"
 		msg += "<span class='info'>Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.</span>"
 	to_chat(src, msg)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -50,17 +50,9 @@
 			else
 				Lines += "[C.key] ([round(C.avgping, 1)]ms)"
 
-	var/player_number = length(Lines)
-	if(length(GLOB.mentors) > 0)
-		Lines += "<b>Mentors:</b>"
-		for(var/client/C in sortList(GLOB.clients))
-			var/mentor = GLOB.mentor_datums[C.ckey]
-			if(mentor)
-				Lines += "<span class='info'>\t[C.key]</span> - Mentor"
-
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
-
+	var/player_number = length(Lines)
 	msg += "<b>Total Players: [player_number]</b>"
 	to_chat(src, msg)
 
@@ -92,5 +84,11 @@
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
 				msg += "\t[C] is a [C.holder.rank]\n"
+	if(length(GLOB.mentors) > 0)
+		msg += "<b>Mentors:</b> \n"
+		for(var/client/C in sortList(GLOB.clients))
+			var/mentor = GLOB.mentor_datums[C.ckey]
+			if(mentor)
+				msg += "<span class='info'>\t[C.key]</span> - Mentor \n"
 		msg += "<span class='info'>Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.</span>"
 	to_chat(src, msg)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -63,7 +63,7 @@
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)
-			msg += "\t[C] is a [C.holder.rank]"
+			msg += "<b>\t[C]</b> is a [C.holder.rank]"
 
 			if(C.holder.fakekey)
 				msg += " <i>(as [C.holder.fakekey])</i>"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -83,12 +83,12 @@
 			if(C.is_afk())
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
-				msg += "\t[C] is a [C.holder.rank]\n"
+				msg += "<b>\t[C]</b> is a [C.holder.rank]\n"
 	if(length(GLOB.mentors) > 0)
 		msg += "<b>Mentors:</b> \n"
 		for(var/client/C in sortList(GLOB.clients))
 			var/mentor = GLOB.mentor_datums[C.ckey]
 			if(mentor)
-				msg += "<span>\t[C.key]</span> is a Mentor \n"
+				msg += "<b>\t[C.key]</b> is a Mentor \n"
 		msg += "<span class='info'>Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.</span>"
 	to_chat(src, msg)


### PR DESCRIPTION
Only took 10 minutes of trying to fix GitHub. Screenshot is below:

![image](https://user-images.githubusercontent.com/25063394/36326663-cbd1d49c-1353-11e8-925f-a68199969cf6.png)

Dont ask why its in blue please
Fixes #628
:cl: AffectedArc07
tweak: Mentors now show in Adminwho instead of Who because that seemed really wierd and not right.
/:cl:
