### PR TITLE
Empty Blood Bag Icon State Fix

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -85,7 +85,6 @@
 
 /obj/item/reagent_containers/blood/empty
 	name = "blood pack"
-	icon_state = "empty"
 
 /obj/item/reagent_containers/blood/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/pen) || istype(I, /obj/item/toy/crayon))


### PR DESCRIPTION
:cl:
fix: Blood bags that start empty are no longer invisible.
/:cl:

Fixes #504 
Alternative solution to #634 

"empty" is not a valid icon state for blood bags - the only icon state a blood bag should ever have is 'bloodbag'.