### PR TITLE
Minor grammar fixes; change reconnect message size

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -252,7 +252,7 @@
 			var/remote_hash = file2text(http["CONTENT"])
 
 			if(local_hash != remote_hash)
-				to_chat(world, "<span class='bignotice'>Server is updating! You may need to reconnect!</span>")
+				to_chat(world, "<span class='narsiesmall'>Server is updating! You may need to reconnect!</span>")
 				shutdown()
 				return
 	..()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -196,7 +196,7 @@
 				for(var/obj/machinery/computer/communications/CM in GLOB.machines)
 					CM.overrideCooldown()
 			if(input["crossmessage"] == "News_Report")
-				minor_announce(input["message"], "Breaking Update From [input["message_sender"]]")
+				minor_announce(input["message"], "Breaking update from [input["message_sender"]]")
 
 	else if("adminmsg" in input)	//tgs2 support
 		if(!key_valid)
@@ -237,8 +237,8 @@
 	ServiceReboot() //handles alternative actions if necessary
 	if (reason || fast_track) //special reboot, do none of the normal stuff
 		if (usr)
-			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
-			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")
+			log_admin("[key_name(usr)] has requested an immediate world restart via client side debugging tools")
+			message_admins("[key_name_admin(usr)] has requested an immediate world restart via client side debugging tools")
 		to_chat(world, "<span class='boldannounce'>Rebooting World immediately due to host request</span>")
 	else
 		to_chat(world, "<span class='boldannounce'>Rebooting world...</span>")
@@ -252,7 +252,7 @@
 			var/remote_hash = file2text(http["CONTENT"])
 
 			if(local_hash != remote_hash)
-				to_chat(world, "<span class='narsie'>Server is updating! You may need to reconnect!</span>")
+				to_chat(world, "<span class='color: red; font-size: 80pt'>Server is updating! You may need to reconnect!</span>")
 				shutdown()
 				return
 	..()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -252,7 +252,7 @@
 			var/remote_hash = file2text(http["CONTENT"])
 
 			if(local_hash != remote_hash)
-				to_chat(world, "<span class='color: red; font-size: 80pt'>Server is updating! You may need to reconnect!</span>")
+				to_chat(world, "<span class='bignotice'>Server is updating! You may need to reconnect!</span>")
 				shutdown()
 				return
 	..()


### PR DESCRIPTION
Here's what I did here:
There were a few minor grammar mistakes, so I decided it won't hurt to fix them. I also made the reconnect message a bit smaller, because some people don't bother to scroll up and see the "Server is updating! You may need to reconnect." They will only see "reconnect." Which will leave some people confused.