### PR TITLE
Reenables plasmamen

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -400,7 +400,7 @@ ROUNDSTART_RACES human
 
 ## Races that are okay-ish on the station. Safe to enable. The number is the minimum hours required to play.
 ROUNDSTART_RACES unathi 10
-#ROUNDSTART_RACES plasmaman 0
+ROUNDSTART_RACES plasmaman 0
 #ROUNDSTART_RACES slime 10
 ROUNDSTART_RACES ethari 0
 ROUNDSTART_RACES human 0


### PR DESCRIPTION
I've seen no actual good reasoning why they were disabled

They're the most mechanically punishing and unique actual xeno race to play, everything else we have currently enabled is "animal but has human features" which is the opposite of the meaning of the word "Xeno" which means alien, as in something not unknown. Hybrids of earth species are not xeno, this on the other hand is real xeno beauty.

👏 