### PR TITLE
Fixes a Tip of the Round

### DIFF
--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -15,7 +15,7 @@ The wizard is supposed to be extremely strong in one on one combat, stop getting
 Sometimes a round will just be a bust. C'est la vie.
 This is a game that is constantly being developed for. Expect things to be added, removed, fixed, and broken on a daily basis.
 It's fun to try and predict the round type from the tip of the round message.
-The quartermaster is not a head of staff and will never be one.
+The quartermaster IS a head of staff.
 The bird remembers.
 Your sprite represents your hitbox, so that afro makes you easier to kill. The sacrifices we make for style.
 Spacemen can't move diagonally but most animals can. Blame the slow decline of the numpad.


### PR DESCRIPTION
:cl: Xantholne
fix: The QM Tip of the Round is now correct instead of giving off false info
/:cl:

Because the Quartermaster IS a head of staff now and the current one is A LYING SACK OF SHIT. HAIL CARGONIA