### PR TITLE
Adminwho will no longer list admins as both admins and mentors

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -87,6 +87,8 @@
 	if(length(GLOB.mentors) > 0)
 		msg += "<b>Mentors:</b> \n"
 		for(var/client/C in sortList(GLOB.clients))
+			if(C in GLOB.admins)
+				return
 			var/mentor = GLOB.mentor_datums[C.ckey]
 			if(mentor)
 				msg += "<b>\t[C.key]</b> is a Mentor \n"


### PR DESCRIPTION
:cl: ike709
tweak: Adminwho will no longer list admins as both admins and mentors
/:cl:

Prevents this:
![image](https://user-images.githubusercontent.com/5714543/36358052-551f200e-14cd-11e8-951f-3ef547a6403f.png)

Anyone incapable of assuming that admins also fill the role of mentors will need more help than any mentor can provide.
