### PR TITLE
Makes mentor OOC color less of an eyesore

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -71,7 +71,7 @@
 			else if(!(key in C.prefs.ignoring))
 				var/ooc_color = GLOB.normal_ooc_colour
 				if(check_mentor())
-					ooc_color = "#FF3E96"
+					ooc_color = "#7289DA"
 				to_chat(C, "<font color='[ooc_color]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>")
 
 /proc/toggle_ooc(toggle = null)


### PR DESCRIPTION
This may or may not be web editor heresy 

:cl: AffectedArc07
tweak: Mentor OOC color no longer hurts your eyes.
/:cl:
![image](https://user-images.githubusercontent.com/25063394/36591070-a733796c-1888-11e8-85f8-64f74051e850.png)

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
