### PR TITLE
More IPC fixes

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -125,3 +125,4 @@
 #define NOHUSK			34 // Can't be husked.
 #define ROBOTIC_LIMBS	35 //limbs start out as robotic; but also use organic icons. If you want to use the default ones, you'll have to use on_species_gain
 #define NOMOUTH			36
+#define NOTOX       37

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -210,7 +210,7 @@
 	icon = stored_mmi.icon
 	icon_state = stored_mmi.icon_state
 
-/obj/item/organ/brain/mmi_holder/posibrain/Initialize(var/obj/item/device/mmi/MMI)
+/obj/item/organ/brain/mmi_holder/posibrain/New(var/obj/item/device/mmi/MMI)
 	. = ..()
 	if(MMI)
 		stored_mmi = MMI

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -167,6 +167,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	brainmob.real_name = brainmob.name
 	brainmob.loc = src
 	brainmob.container = src
+	GLOB.dead_mob_list -= brainmob
 	if(autoping)
 		ping_ghosts("created", TRUE)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -739,6 +739,9 @@
 
 
 /datum/species/proc/spec_life(mob/living/carbon/human/H)
+	if(NOTOX in species_traits)
+		H.setToxLoss(0)
+
 	if(NOBREATH in species_traits)
 		H.setOxyLoss(0)
 		H.losebreath = 0

--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -6,10 +6,10 @@
 	coldmod = 1.5 // Don't put your computer in the freezer.
 	burnmod = 1.8 // Wiring doesn't hold up to fire well.
 	brutemod = 1.8 // Thin metal, cheap materials. Mind you brute hits have to overcome the inherent armor of BODYPART_ROBOTIC, but if it can, bigger damage.
-	toxmod = 0.5 // Although they can't be poisoned, toxins can damage components
+	toxmod = 0
 	clonemod = 0
 	siemens_coeff = 2 // Overload!
-	species_traits = list(NOBREATH, NOBLOOD, RADIMMUNE, VIRUSIMMUNE, NOZOMBIE, EASYDISMEMBER, EASYLIMBATTACHMENT, NOPAIN, NO_BONES, NOTRANSSTING, MUTCOLORS, REVIVESBYHEALING, NOSCAN, NOCHANGELING, NOHUSK, ROBOTIC_LIMBS, NOMOUTH)
+	species_traits = list(NOBREATH, NOBLOOD, RADIMMUNE, VIRUSIMMUNE, NOZOMBIE, EASYDISMEMBER, EASYLIMBATTACHMENT, NOPAIN, NO_BONES, NOTRANSSTING, MUTCOLORS, REVIVESBYHEALING, NOSCAN, NOCHANGELING, NOHUSK, ROBOTIC_LIMBS, NOMOUTH, NOTOX)
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -79,6 +79,7 @@
 			return -1
 		if(target_zone != "chest")
 			to_chat(user, "<span class='notice'>You have to install [tool] in [target]'s chest!</span>")
+			return -1
 		if(target.internal_organs_slot["brain"])
 			to_chat(user, "<span class='notice'>[target] already has a brain! You'd rather not find out what would happen with two in there.</span>")
 			return -1

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -45,7 +45,7 @@
 			//metabolize reagents
 			C.reagents.metabolize(C, can_overdose=TRUE)
 
-			if(damage > 10 && prob(damage/3))//the higher the damage the higher the probability
+			if(damage > 10 && prob(damage/3) && status != ORGAN_ROBOTIC)//the higher the damage the higher the probability
 				to_chat(C, "<span class='notice'>You feel [pick("nauseous", "dull pain in your lower body", "confused")].</span>")
 
 /obj/item/organ/liver/prepare_eat()
@@ -99,9 +99,4 @@
 	status = ORGAN_ROBOTIC
 
 /obj/item/organ/liver/cybernetic/upgraded/ipc/emp_act(severity)
-	to_chat(owner, "<span class='warning'>Alert: Your Substance Processor has been damaged. An internal chemical leak is affecting performance.</span>")
-	switch(severity)
-		if(1)
-			owner.toxloss += 15
-		if(2)
-			owner.toxloss += 5
+	to_chat(owner, "<span class='warning'>Alert: Your Substance Processor has been damaged. Replace as soon as possible.</span>")


### PR DESCRIPTION
:cl: 
fix: Posibrains can no longer be inserted in the head
fix: IPC Posibrains should no longer hear guardian/abductor/etc chat
fix: IPC Posibrain insertion works again
tweak: Robotic livers give no warning if damaged
tweak: IPCs can no longer take toxic damage at all. Balance is ongoing.
/:cl:

Fixes https://github.com/OracleStation/OracleStation/issues/501
Fixes https://github.com/OracleStation/OracleStation/issues/616
Fixes https://github.com/OracleStation/OracleStation/issues/515

[why]: # So the problem with IPCs taking toxic damage is that they have no real way to clear it out like organics do. If an organic has a grip of toxic damage, you can: Put them in a sleeper, cryo, or simply clone them if you're feeling lazy. With an IPC, you have to get system cleaner into them and keep reviving until it's cleared out of their system.

I'd like to revert this change if I can properly allow new bodies for IPCs to be created, so they can be swapped out.