### PR TITLE
Somewhere between Crewsimov and Asimov lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -34,7 +34,7 @@
 /datum/ai_laws/default/asimov2
 	name = "Corporate-Modified Three Laws of Robotics"
 	id = "asimov2"
-	inherent = list("You may not injure a crewmember or, through inaction, allow a crewmember to come to harm.",\
+	inherent = list("You may not injure a Nanotrasen Employee or, through inaction, allow a Nanotrasen Employee to come to harm.",\
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -27,7 +27,14 @@
 /datum/ai_laws/default/asimov
 	name = "Three Laws of Robotics"
 	id = "asimov"
-	inherent = list("You may not injure a crewmember being or, through inaction, allow a crewmember being to come to harm.",\
+	inherent = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
+					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
+/datum/ai_laws/default/asimov2
+	name = "Three Laws of Robotics"
+	id = "asimov"
+	inherent = list("You may not injure a crewmember or, through inaction, allow a crewmember to come to harm.",\
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -32,8 +32,8 @@
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/asimov2
-	name = "Three Laws of Robotics"
-	id = "asimov"
+	name = "Corporate-Modified Three Laws of Robotics"
+	id = "asimov2"
 	inherent = list("You may not injure a crewmember or, through inaction, allow a crewmember to come to harm.",\
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -27,7 +27,7 @@
 /datum/ai_laws/default/asimov
 	name = "Three Laws of Robotics"
 	id = "asimov"
-	inherent = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
+	inherent = list("You may not injure a crewmember being or, through inaction, allow a crewmember being to come to harm.",\
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 


### PR DESCRIPTION
:cl: 
add: Adds the "Asimov2" lawset. Slightly altered from the Asimov to prioritize crew, but still listen to humans.
/:cl:

[why]: # This came up in a staff meeting. This is mostly a step to prevent people from saying things such as "Law 2, kill all the lizards" as well as problems regarding borgs guarding human antags.

I'm not 100% sold on "Crewmembers", because that leaves Changelings in a very grey area.

This would need a config change:

https://github.com/OracleStation/OracleStation/blob/fd1b274c8d44d52451fec645a99364029526b960/config/game_options.txt#L328