### PR TITLE
Replica pods work again

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -26,7 +26,7 @@
 	if(istype(W, /obj/item/reagent_containers/syringe))
 		if(!contains_sample)
 			for(var/datum/reagent/blood/bloodSample in W.reagents.reagent_list)
-				if(bloodSample.data["mind"] && bloodSample.data["cloneable"] == 1)
+				if(bloodSample.data["mind"] && bloodSample.data["cloneable"] != 0)
 					mind = bloodSample.data["mind"]
 					ckey = bloodSample.data["ckey"]
 					realName = bloodSample.data["real_name"]


### PR DESCRIPTION
:cl: 
fix: Replica pods work again
/:cl:

Fixes https://github.com/OracleStation/OracleStation/issues/462
Fixes https://github.com/OracleStation/OracleStation/issues/494

I'm not sure why this broke, but I couldn't find anything in the bloodcode that would make `data["cloneable"] = 1`. So I just made it so it works if it doesn't equal 0, because 0 only appears when there is mixed blood inside the syringe.