### PR TITLE
Emagging a shuttle now violently throws people without seatbelts on ignition, and has a chance to break seatbelts.

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -129,7 +129,7 @@
 		// shuttle timers use 1/10th seconds internally
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		var/system_error = emagged ? "SYSTEM ERROR:" : null
-		var/emag_boost_message = pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "WHEN THIS BABY HITS 88 MILLION MILES PER HOUR YOU'RE GONNA SEE SOME SERIOUS SHIT", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE", "WHAT IF THE ENGINES MOVE THE UNIVERSE, NOT THE SHUTTLE?")
+		var/emag_boost_message = pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")
 		minor_announce("The emergency shuttle will launch in \
 			[TIME_LEFT] seconds.\n[emag_boost_message]", system_error, alert=TRUE)
 		. = TRUE

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -129,8 +129,9 @@
 		// shuttle timers use 1/10th seconds internally
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		var/system_error = emagged ? "SYSTEM ERROR:" : null
+		var/emag_boost_message = pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "WHEN THIS BABY HITS 88 MILLION MILES PER HOUR YOU'RE GONNA SEE SOME SERIOUS SHIT", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE", "WHAT IF THE ENGINES MOVE THE UNIVERSE, NOT THE SHUTTLE?")
 		minor_announce("The emergency shuttle will launch in \
-			[TIME_LEFT] seconds", system_error, alert=TRUE)
+			[TIME_LEFT] seconds.\n[emag_boost_message]", system_error, alert=TRUE)
 		. = TRUE
 
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
@@ -150,6 +151,7 @@
 	log_game("[key_name(user)] has emagged the emergency shuttle in \
 		[COORD(src)] [time] seconds before launch.")
 	emagged = TRUE
+	SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 10, "THROW" = 20, "IGNOREBUCKLE" = TRUE)
 	var/datum/species/S = new
 	for(var/i in 1 to 10)
 		// the shuttle system doesn't know who these people are, but they

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -324,7 +324,7 @@ All ShuttleMove procs go here
 
 /mob/living/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
-	if(movement_force["IGNOREBUCKLE"] && buckled && prob(50))//GET READY FOR A WILD RIDE
+	if(movement_force["IGNOREBUCKLE"] && buckled && prob(33))//GET READY FOR A WILD RIDE
 		src.buckled.unbuckle_mob(src)
 		src.visible_message(\
 		"<span class='warning'>[src] is torn from the buckle by the force of the movement!</span>",\

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -324,6 +324,13 @@ All ShuttleMove procs go here
 
 /mob/living/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
+	if(movement_force["IGNOREBUCKLE"] && buckled && prob(50))//GET READY FOR A WILD RIDE
+		src.buckled.unbuckle_mob(src)
+		src.visible_message(\
+		"<span class='warning'>[src] is torn from the buckle by the force of the movement!</span>",\
+		"<span class='warning'>You're torn from the buckle by the force of the movement!'.</span>",\
+		"<span class='italics'>You hear metal clanking.</span>")
+
 	if(movement_force && !buckled)
 		if(movement_force["THROW"])
 			var/throw_dir = move_dir
@@ -357,7 +364,7 @@ All ShuttleMove procs go here
 	var/turf/T = loc
 	if(level==1)
 		hide(T.intact)
-		
+
 /obj/structure/shuttle/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	. |= MOVE_CONTENTS

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -269,7 +269,7 @@
 
 	var/launch_status = NOLAUNCH
 
-	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
+	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 1, "IGNOREBUCKLE" = FALSE)
 
 	// A timid shuttle will not register itself with the shuttle subsystem
 	// All shuttle templates are timid


### PR DESCRIPTION
:cl: MrDoomBringer & Ziiro
add: Emagging a shuttle gives the engines extra kick, launching people who are not buckled (50% chance to break seatbelts)
tweak: There is a random message underneath the hijack message now, really letting people know that they're going to want to **buckle the fuck up.**
tweak: All shuttle movement will now move people who aren't buckled 1 tile.
/:cl:

Ports https://github.com/tgstation/tgstation/pull/36050

[why]: I'm pretty sure this will never not be funny.

![2018-03-01_00-43-21](https://user-images.githubusercontent.com/26494679/36834624-b278e9d0-1cf0-11e8-9cf0-4087297406d8.gif)

Additionally, it adds some more risk to the hijacker, and gives them different ways to get people the fuck off their shuttle if they're clever.

![dreamseeker_2018-03-01_00-43-36](https://user-images.githubusercontent.com/26494679/36834648-c54febe4-1cf0-11e8-963e-a1a1a75075cc.png)

I can add or remove any lines you find too memey.