### PR TITLE
Return of the Plasmamen

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -22,6 +22,8 @@
 	ass_pic = "plasmaman"
 	examine_text = "a Plasmaman"
 	species_text_color = "#800064"
+	loreblurb = "The product of plasma experimentation on a human colony, these strange abominations lead a difficult life of breathing plasma and bursting into flames when exposed to oxygen. \
+	Logically speaking, they make for bad crewmembers. However, they don't have a choice but to work for the only corporation that can supply them with plasma."
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/datum/gas_mixture/environment = H.loc.return_air()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -400,7 +400,7 @@ ROUNDSTART_RACES human
 
 ## Races that are okay-ish on the station. Safe to enable. The number is the minimum hours required to play.
 ROUNDSTART_RACES unathi 10
-#ROUNDSTART_RACES plasmaman 0
+ROUNDSTART_RACES plasmaman 20
 #ROUNDSTART_RACES slime 10
 ROUNDSTART_RACES ethari 0
 ROUNDSTART_RACES human 0


### PR DESCRIPTION
:cl: 
add: Plasmaman Lore Blurb
/:cl:

Followup to https://github.com/OracleStation/OracleStation/pull/638 . Adds a loreblurb, this will need a config update. I suggest 100 hours of gametime to play as a plasma man to keep them rare (and so people have a better understanding of mechanics before playing a race this dangerous.)