### PR TITLE
Antag reputation port

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -94,6 +94,20 @@ CONFIG_DEF(flag/enforce_human_authority)	//If non-human species are barred from 
 
 CONFIG_DEF(flag/allow_latejoin_antagonists)	// If late-joining players can be traitor/changeling
 
+CONFIG_DEF(flag/use_antag_rep) // see game_options.txt for details
+
+CONFIG_DEF(number/antag_rep_maximum)
+	value = 200
+	min_val = 0
+
+CONFIG_DEF(number/default_antag_tickets)
+	value = 100
+	min_val = 0
+
+CONFIG_DEF(number/max_tickets_per_roll)
+	value = 100
+	min_val = 0
+
 CONFIG_DEF(number/midround_antag_time_check)	// How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	value = 60
 	min_val = 0

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -439,6 +439,8 @@ SUBSYSTEM_DEF(job)
 			else
 				M = H
 
+	SSpersistence.antag_rep_change[M.client.ckey] += job.antag_rep
+
 	to_chat(M, "<b>You are the [rank].</b>")
 	to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 	to_chat(M, "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -430,6 +430,10 @@ SUBSYSTEM_DEF(job)
 	if(H.mind)
 		H.mind.assigned_role = rank
 
+	if(iscarbon(H))
+		var/mob/living/carbon/C = H
+		C.latest_id_job = rank
+
 	if(job)
 		var/new_mob = job.equip(H)
 		if(ismob(new_mob))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -190,21 +190,6 @@ SUBSYSTEM_DEF(job)
 				return 1
 	return 0
 
-/datum/controller/subsystem/job/proc/FillPosition(datum/job/job)
-	for(var/level = 1 to 3)
-		if(!job)
-			continue
-		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-			continue
-		var/list/candidates = FindOccupationCandidates(job, level)
-		if(!candidates.len)
-			continue
-		var/mob/dead/new_player/candidate = pick(candidates)
-		if(AssignRole(candidate, job.title))
-			return 1
-	return 0
-
-
 //This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
 //This is also to ensure we get as many heads as possible
 /datum/controller/subsystem/job/proc/CheckHeadPositions(level)
@@ -299,12 +284,6 @@ SUBSYSTEM_DEF(job)
 	Debug("DO, Running AI Check")
 	FillAIPosition()
 	Debug("DO, AI Check end")
-
-	//Fill security roles
-	Debug("DO, Running Security Check")
-	FillPosition(GetJob("Security Officer"))
-	Debug("DO, Security Check end")
-
 
 	//Other jobs are now checked
 	Debug("DO, Running Standard Check")

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -219,10 +219,14 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectAntagReputation()
 	var/ANTAG_REP_MAXIMUM = CONFIG_GET(number/antag_rep_maximum)
 
-	for(var/p_ckey in antag_rep_change)
-		//var/start = antag_rep[p_ckey]
+	for(var/p_ckey in antag_rep_change
+		#ifdef TESTING
+		var/start = antag_rep[p_ckey]
+		#endif
 		antag_rep[p_ckey] = max(0, min(antag_rep[p_ckey]+antag_rep_change[p_ckey], ANTAG_REP_MAXIMUM))
-		//WARNING("AR_DEBUG: [p_ckey]: Committed [antag_rep_change[p_ckey]] reputation, going from [start] to [antag_rep[p_ckey]]")
+		#ifdef TESTING
+		testing("AR_DEBUG: [p_ckey]: Committed [antag_rep_change[p_ckey]] reputation, going from [start] to [antag_rep[p_ckey]]")
+		#endif
 
 	antag_rep_change = list()
 
@@ -248,7 +252,9 @@ SUBSYSTEM_DEF(persistence)
 	// people who died or left should not gain any reputation
 	// people who rolled antagonist still lose it
 	if(failed && SSpersistence.antag_rep_change[p_ckey] > 0)
-		//WARNING("AR_DEBUG: Zeroed [p_ckey]'s antag_rep_change due to failure")
+		#ifdef TESTING
+		testing("AR_DEBUG: Zeroed [p_ckey]'s antag_rep_change due to failure")
+		#endif
 		SSpersistence.antag_rep_change[p_ckey] = 0
 
 	var/mob/living/carbon/C = player
@@ -258,5 +264,7 @@ SUBSYSTEM_DEF(persistence)
 	//If they changed jobs to a higher rep, it'll still be the original job's rep so let's only worry about lower
 	if(current_job.antag_rep < original_job.antag_rep)
 		if(SSpersistence.antag_rep_change[p_ckey] > 0)
-			//WARNING("AR_DEBUG: Reduced [p_ckey]'s antag_rep_change due to higher rep job change")
+			#ifdef TESTING
+			testing("AR_DEBUG: Reduced [p_ckey]'s antag_rep_change due to higher rep job change")
+			#endif
 			SSpersistence.antag_rep_change[p_ckey] = current_job.antag_rep

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -234,8 +234,6 @@ SUBSYSTEM_DEF(persistence)
 	text2file(json_encode(antag_rep), FILE_ANTAG_REP)
 
 /datum/controller/subsystem/persistence/proc/antag_rep_check(mob/player)
-	if(!iscarbon(player))
-		return
 	if(!player.ckey || !player.client)
 		return
 	var/failed = FALSE
@@ -257,6 +255,11 @@ SUBSYSTEM_DEF(persistence)
 		#endif
 		SSpersistence.antag_rep_change[p_ckey] = 0
 
+	if(!iscarbon(player))
+		#ifdef TESTING
+		testing("AR_DEBUG: [player] ([p_ckey]) is not a carbon mob, job change not checked")
+		#endif
+		return
 	var/mob/living/carbon/C = player
 	var/datum/job/current_job = SSjob.GetJob(C.latest_id_job)
 	var/datum/job/original_job = SSjob.GetJob(C.mind.assigned_role)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -219,7 +219,7 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectAntagReputation()
 	var/ANTAG_REP_MAXIMUM = CONFIG_GET(number/antag_rep_maximum)
 
-	for(var/p_ckey in antag_rep_change
+	for(var/p_ckey in antag_rep_change)
 		#ifdef TESTING
 		var/start = antag_rep[p_ckey]
 		#endif

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -481,7 +481,7 @@ SUBSYSTEM_DEF(ticker)
 
 	//Player status report
 	for(var/mob/Player in GLOB.mob_list)
-		if(CONFIG_GET(flag/use_antag_rep))
+		if(CONFIG_GET(flag/use_antag_rep) && Player.client)
 			SSpersistence.antag_rep_check(Player)
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD && !isbrain(Player))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -481,6 +481,8 @@ SUBSYSTEM_DEF(ticker)
 
 	//Player status report
 	for(var/mob/Player in GLOB.mob_list)
+		if(CONFIG_GET(flag/use_antag_rep))
+			SSpersistence.antag_rep_check(Player)
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD && !isbrain(Player))
 				num_survivors++

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_EMPTY(blobs_legit) //used for win-score calculations, contains only 
 	for(var/j = 0, j < cores_to_spawn, j++)
 		if (!antag_candidates.len)
 			break
-		var/datum/mind/blob = pick(antag_candidates)
+		var/datum/mind/blob = antag_pick(antag_candidates)
 		blob_overminds += blob
 		blob.assigned_role = "Blob"
 		blob.special_role = "Blob"

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -1,6 +1,6 @@
 /datum/objective_team/brother_team
-	name = "brotherhood" 
-	member_name = "blood brother" 
+	name = "brotherhood"
+	member_name = "blood brother"
 	var/list/objectives = list()
 	var/meeting_area
 
@@ -71,12 +71,12 @@
 		num_teams = max(1, round(num_players() / bsc))
 
 	for(var/j = 1 to num_teams)
-		if(possible_brothers.len < min_team_size || antag_candidates.len <= required_enemies) 
+		if(possible_brothers.len < min_team_size || antag_candidates.len <= required_enemies)
 			break
 		var/datum/objective_team/brother_team/team = new
 		var/team_size = prob(10) ? min(3, possible_brothers.len) : 2
 		for(var/k = 1 to team_size)
-			var/datum/mind/bro = pick(possible_brothers)
+			var/datum/mind/bro = antag_pick(possible_brothers)
 			possible_brothers -= bro
 			antag_candidates -= bro
 			team.members += bro

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	if(antag_candidates.len>0)
 		for(var/i = 0, i < num_changelings, i++)
 			if(!antag_candidates.len) break
-			var/datum/mind/changeling = pick(antag_candidates)
+			var/datum/mind/changeling = antag_pick(antag_candidates)
 			antag_candidates -= changeling
 			changelings += changeling
 			changeling.special_role = "Changeling"

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -44,7 +44,7 @@
 	if(possible_changelings.len>0)
 		for(var/j = 0, j < num_changelings, j++)
 			if(!possible_changelings.len) break
-			var/datum/mind/changeling = pick(possible_changelings)
+			var/datum/mind/changeling = antag_pick(possible_changelings)
 			antag_candidates -= changeling
 			possible_changelings -= changeling
 			changeling.special_role = "Changeling"

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -120,7 +120,7 @@ Credit where due:
 		starter_servants += round(number_players / 10)
 	starter_servants = min(starter_servants, 8) //max 8 servants (that sould only happen with a ton of players)
 	while(starter_servants)
-		var/datum/mind/servant = pick(antag_candidates)
+		var/datum/mind/servant = antag_pick(antag_candidates)
 		servants_to_serve += servant
 		antag_candidates -= servant
 		modePlayer += servant

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -67,7 +67,7 @@
 	for(var/cultists_number = 1 to recommended_enemies)
 		if(!antag_candidates.len)
 			break
-		var/datum/mind/cultist = pick(antag_candidates)
+		var/datum/mind/cultist = antag_pick(antag_candidates)
 		antag_candidates -= cultist
 		cultists_to_cult += cultist
 		cultist.special_role = "Cultist"

--- a/code/game/gamemodes/devil/devil_game_mode.dm
+++ b/code/game/gamemodes/devil/devil_game_mode.dm
@@ -35,7 +35,7 @@
 	for(var/j = 0, j < num_devils, j++)
 		if (!antag_candidates.len)
 			break
-		var/datum/mind/devil = pick(antag_candidates)
+		var/datum/mind/devil = antag_pick(antag_candidates)
 		devils += devil
 		devil.special_role = traitor_name
 		devil.restricted_roles = restricted_jobs

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -310,6 +310,59 @@
 	if(GLOB.security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)
 
+// This is a frequency selection system. You may imagine it like a raffle where each player can have some number of tickets. The more tickets you have the more likely you are to
+// "win". The default is 100 tickets. If no players use any extra tickets (earned with the antagonist rep system) calling this function should be equivalent to calling the normal
+// pick() function. By default you may use up to 100 extra tickets per roll, meaning at maximum a player may double their chances compared to a player who has no extra tickets.
+//
+// The odds of being picked are simply (your_tickets / total_tickets). Suppose you have one player using fifty (50) extra tickets, and one who uses no extra:
+//     Player A: 150 tickets
+//     Player B: 100 tickets
+//        Total: 250 tickets
+//
+// The odds become:
+//     Player A: 150 / 250 = 0.6 = 60%
+//     Player B: 100 / 250 = 0.4 = 40%
+/datum/game_mode/proc/antag_pick(list/datum/candidates)
+	if(!CONFIG_GET(flag/use_antag_rep))
+		return pick(candidates)
+
+	// Tickets start at 100
+	var/DEFAULT_ANTAG_TICKETS = CONFIG_GET(number/default_antag_tickets)
+
+	// You may use up to 100 extra tickets (double your odds)
+	var/MAX_TICKETS_PER_ROLL = CONFIG_GET(number/max_tickets_per_roll)
+
+
+	var/total_tickets = 0
+
+	MAX_TICKETS_PER_ROLL += DEFAULT_ANTAG_TICKETS
+
+	var/p_ckey
+	var/p_rep
+
+	for(var/datum/mind/mind in candidates)
+		p_ckey = ckey(mind.key)
+		total_tickets += min(SSpersistence.antag_rep[p_ckey] + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
+
+	var/antag_select = rand(1,total_tickets)
+	var/current = 1
+
+	for(var/datum/mind/mind in candidates)
+		p_ckey = ckey(mind.key)
+		p_rep = SSpersistence.antag_rep[p_ckey]
+		p_rep = p_rep == null ? 0 : p_rep
+
+		if(current <= antag_select)
+			var/subtract = min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL) - DEFAULT_ANTAG_TICKETS
+			SSpersistence.antag_rep_change[p_ckey] = -subtract
+			//WARNING("AR_DEBUG: Player [mind.key] won spending [subtract] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
+
+			return mind
+
+		current += min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
+
+	WARNING("Something has gone terribly wrong. /datum/game_mode/proc/antag_pick failed to select a candidate. Falling back to pick()")
+	return pick(candidates)
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
@@ -473,16 +526,26 @@
 
 
 		if(L.ckey && L.client)
+			var/failed = FALSE
 			if(L.client.inactivity >= (ROUNDSTART_LOGOUT_REPORT_TIME / 2))	//Connected, but inactive (alt+tabbed or something)
 				msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
-				continue //AFK client
-			if(L.stat)
-				if(L.stat == UNCONSCIOUS)
+				failed = TRUE //AFK client
+			if(!failed && L.stat)
+				if(!failed && L.stat == UNCONSCIOUS)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dying)\n"
-					continue //Unconscious
-				if(L.stat == DEAD)
+					failed = TRUE //Unconscious
+				if(!failed && L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
-					continue //Dead
+					failed = TRUE //Dead
+
+			var/p_ckey = L.client.ckey
+			//WARNING("AR_DEBUG: [p_ckey]: failed - [failed], antag_rep_change: [SSpersistence.antag_rep_change[p_ckey]]")
+
+			// people who died or left should not gain any reputation
+			// people who rolled antagonist still lose it
+			if(failed && SSpersistence.antag_rep_change[p_ckey] > 0)
+				//WARNING("AR_DEBUG: Zeroed [p_ckey]'s antag_rep_change")
+				SSpersistence.antag_rep_change[p_ckey] = 0
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -553,8 +553,10 @@
 						continue //Ghosted while alive
 
 	for(var/mob/M in GLOB.mob_list)
-		if(M.client && M.client.holder)
-			to_chat(M, msg)
+		if(M.client)
+			antag_rep_check(M)
+			if(M.client.holder)
+				to_chat(M, msg)
 
 /datum/game_mode/proc/printplayer(datum/mind/ply, fleecheck)
 	var/text = "<br><b>[ply.key]</b> was <b>[ply.name]</b> the <b>[ply.assigned_role]</b> and"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -554,7 +554,7 @@
 
 	for(var/mob/M in GLOB.mob_list)
 		if(M.client)
-			antag_rep_check(M)
+			SSpersistence.antag_rep_check(M)
 			if(M.client.holder)
 				to_chat(M, msg)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -537,16 +537,6 @@
 				if(!failed && L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
 					failed = TRUE //Dead
-
-			var/p_ckey = L.client.ckey
-			//WARNING("AR_DEBUG: [p_ckey]: failed - [failed], antag_rep_change: [SSpersistence.antag_rep_change[p_ckey]]")
-
-			// people who died or left should not gain any reputation
-			// people who rolled antagonist still lose it
-			if(failed && SSpersistence.antag_rep_change[p_ckey] > 0)
-				//WARNING("AR_DEBUG: Zeroed [p_ckey]'s antag_rep_change")
-				SSpersistence.antag_rep_change[p_ckey] = 0
-
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)
 			if(D.mind && D.mind.current == L)
@@ -559,8 +549,6 @@
 					else
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='boldannounce'>Ghosted</span>)\n"
 						continue //Ghosted while alive
-
-
 
 	for(var/mob/M in GLOB.mob_list)
 		if(M.client && M.client.holder)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -350,18 +350,19 @@
 	for(var/datum/mind/mind in candidates)
 		p_ckey = ckey(mind.key)
 		p_rep = SSpersistence.antag_rep[p_ckey]
-		p_rep = p_rep == null ? 0 : p_rep
 
-		if(antag_select <= current)
-			var/subtract = min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL) - DEFAULT_ANTAG_TICKETS
-			SSpersistence.antag_rep_change[p_ckey] = -subtract
+		var/previous = current
+		var/spend = min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
+		current += spend
+
+		if(antag_select >= previous && antag_select <= (current-1))
+			SSpersistence.antag_rep_change[p_ckey] = -(spend - DEFAULT_ANTAG_TICKETS)
+
 			#ifdef TESTING
 			testing("AR_DEBUG: Player [mind.key] won spending [subtract] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
 			#endif
 
 			return mind
-
-		current += min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
 
 	WARNING("Something has gone terribly wrong. /datum/game_mode/proc/antag_pick failed to select a candidate. Falling back to pick()")
 	return pick(candidates)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -528,17 +528,17 @@
 
 
 		if(L.ckey && L.client)
-			var/failed = FALSE
 			if(L.client.inactivity >= (ROUNDSTART_LOGOUT_REPORT_TIME / 2))	//Connected, but inactive (alt+tabbed or something)
 				msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
-				failed = TRUE //AFK client
-			if(!failed && L.stat)
-				if(!failed && L.stat == UNCONSCIOUS)
+				continue //AFK client
+			if(L.stat)
+				if(L.stat == UNCONSCIOUS)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dying)\n"
-					failed = TRUE //Unconscious
-				if(!failed && L.stat == DEAD)
+					continue //Unconscious
+				if(L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
-					failed = TRUE //Dead
+					continue //Dead
+
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)
 			if(D.mind && D.mind.current == L)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -355,7 +355,9 @@
 		if(current <= antag_select)
 			var/subtract = min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL) - DEFAULT_ANTAG_TICKETS
 			SSpersistence.antag_rep_change[p_ckey] = -subtract
-			//WARNING("AR_DEBUG: Player [mind.key] won spending [subtract] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
+			#ifdef TESTING
+			testing("AR_DEBUG: Player [mind.key] won spending [subtract] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
+			#endif
 
 			return mind
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -359,7 +359,8 @@
 			SSpersistence.antag_rep_change[p_ckey] = -(spend - DEFAULT_ANTAG_TICKETS)
 
 			#ifdef TESTING
-			testing("AR_DEBUG: Player [mind.key] won spending [subtract] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
+			var/cost = spend - DEFAULT_ANTAG_TICKETS
+			testing("AR_DEBUG: Player [mind.key] won spending [cost] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")
 			#endif
 
 			return mind

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -352,7 +352,7 @@
 		p_rep = SSpersistence.antag_rep[p_ckey]
 		p_rep = p_rep == null ? 0 : p_rep
 
-		if(current <= antag_select)
+		if(antag_select <= current)
 			var/subtract = min(p_rep + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL) - DEFAULT_ANTAG_TICKETS
 			SSpersistence.antag_rep_change[p_ckey] = -subtract
 			#ifdef TESTING

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(gang_outfit_pool, list(/obj/item/clothing/suit/jacket/leather, 
 
 		//Now assign a boss for the gang
 		for(var/n in 1 to 3)
-			var/datum/mind/boss = pick(antag_candidates)
+			var/datum/mind/boss = antag_pick(antag_candidates)
 			antag_candidates -= boss
 			G.bosses[boss] = GANGSTER_BOSS_STARTING_INFLUENCE
 			boss.gang_datum = G

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -58,13 +58,13 @@
 	var/datum/mind/agent
 
 	if(!preset_scientist)
-		scientist = pick(antag_candidates)
+		scientist = antag_pick(antag_candidates)
 		antag_candidates -= scientist
 	else
 		scientist = preset_scientist
 
 	if(!preset_agent)
-		agent = pick(antag_candidates)
+		agent = antag_pick(antag_candidates)
 		antag_candidates -= agent
 	else
 		agent = preset_agent

--- a/code/game/gamemodes/miniantags/monkey/monkey.dm
+++ b/code/game/gamemodes/miniantags/monkey/monkey.dm
@@ -27,7 +27,7 @@
 	for(var/j = 0, j < carriers_to_make, j++)
 		if (!antag_candidates.len)
 			break
-		var/datum/mind/carrier = pick(antag_candidates)
+		var/datum/mind/carrier = antag_pick(antag_candidates)
 		carriers += carrier
 		carrier.special_role = "monkey"
 		carrier.restricted_roles = restricted_jobs

--- a/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
@@ -33,7 +33,7 @@
 		message_admins("No valid spawn locations found, aborting...")
 		return MAP_ERROR
 
-	var /obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter((pick(spawn_locs)))
+	var/obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter((spawn_locs))
 	var/mob/living/simple_animal/slaughter/S = new /mob/living/simple_animal/slaughter/(holder)
 	S.holder = holder
 	player_mind.transfer_to(S)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -30,7 +30,7 @@
 		n_agents = antag_candidates.len
 
 	while(n_agents > 0)
-		var/datum/mind/new_syndicate = pick(antag_candidates)
+		var/datum/mind/new_syndicate = antag_pick(antag_candidates)
 		syndicates += new_syndicate
 		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
 		n_agents--

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -52,7 +52,7 @@
 	for (var/i=1 to max_headrevs)
 		if (antag_candidates.len==0)
 			break
-		var/datum/mind/lenin = pick(antag_candidates)
+		var/datum/mind/lenin = antag_pick(antag_candidates)
 		antag_candidates -= lenin
 		head_revolutionaries += lenin
 		lenin.restricted_roles = restricted_jobs
@@ -213,7 +213,7 @@
 				if(ROLE_REV in khrushchev.current.client.prefs.be_special)
 					promotable_revs += khrushchev
 		if(promotable_revs.len)
-			var/datum/mind/stalin = pick(promotable_revs)
+			var/datum/mind/stalin = antag_pick(promotable_revs)
 			revolutionaries -= stalin
 			head_revolutionaries += stalin
 			log_game("[stalin.key] (ckey) has been promoted to a head rev")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -47,7 +47,7 @@
 	for(var/j = 0, j < num_traitors, j++)
 		if (!antag_candidates.len)
 			break
-		var/datum/mind/traitor = pick(antag_candidates)
+		var/datum/mind/traitor = antag_pick(antag_candidates)
 		pre_traitors += traitor
 		traitor.special_role = traitor_name
 		traitor.restricted_roles = restricted_jobs

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -20,7 +20,7 @@
 
 /datum/game_mode/wizard/pre_setup()
 
-	var/datum/mind/wizard = pick(antag_candidates)
+	var/datum/mind/wizard = antag_pick(antag_candidates)
 	wizards += wizard
 	modePlayer += wizard
 	wizard.assigned_role = "Wizard"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -98,6 +98,14 @@
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 
+/obj/item/card/id/equipped(mob/user, slot)
+	..()
+	if(!iscarbon(user) || slot != slot_wear_id)
+		return
+	var/mob/living/carbon/C = user
+	if(C.real_name == src.registered_name)
+		C.latest_id_job = src.assignment
+
 /obj/item/card/id/vv_edit_var(var_name, var_value)
 	. = ..()
 	if(.)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -84,6 +84,14 @@ GLOBAL_LIST_EMPTY(PDAs)
 /obj/item/device/pda/GetID()
 	return id
 
+/obj/item/device/pda/equipped(mob/user, slot)
+	..()
+	if(!iscarbon(user) || slot != slot_wear_id || !GetID())
+		return
+	var/mob/living/carbon/C = user
+	if(C.real_name == id.registered_name)
+		C.latest_id_job = id.assignment
+
 /obj/item/device/pda/update_icon()
 	cut_overlays()
 	var/mutable_appearance/overlay = new()
@@ -691,6 +699,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 		id = I
 		if(old_id)
 			user.put_in_hands(old_id)
+		if(user.get_item_by_slot(slot_wear_id) == src && iscarbon(user) && user.real_name == id.registered_name)
+			var/mob/living/carbon/player = user
+			player.latest_id_job = id.assignment
 		update_icon()
 	return 1
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -44,6 +44,13 @@
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"
+		var/rep = 0
+		rep += SSpersistence.antag_rep[M.ckey]
+		body += "<br><br>Antagonist reputation: [rep]"
+		body += "<br><a href='?_src_=holder;[HrefToken()];modantagrep=add;mob=[REF(M)]'>\[increase\]</a> "
+		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=subtract;mob=[REF(M)]'>\[decrease\]</a> "
+		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=set;mob=[REF(M)]'>\[set\]</a> "
+		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=zero;mob=[REF(M)]'>\[zero\]</a>"
 
 
 	body += "<br><br>\[ "

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2486,6 +2486,15 @@
 			to_chat(usr, "<span class='warning'>The faxed item is not viewable. This is probably a bug, and should be reported on the tracker: [fax.type]</span>")
 		return
 
+	else if(href_list["modantagrep"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locate(href_list["mob"]) in GLOB.mob_list
+		var/client/C = M.client
+		usr.client.cmd_admin_mod_antag_rep(C, href_list["modantagrep"])
+		show_player_panel(M)
+
 /datum/admins/proc/handle_sendall(var/obj/machinery/photocopier/faxmachine/F, var/obj/item/paper/P)
 	if(F.receivefax(P) == FALSE)
 		to_chat(owner, "<span class='warning'>Message transmission to [F.department] failed.</span>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -47,6 +47,52 @@
 	admin_ticket_log(M, msg)
 	SSblackbox.add_details("admin_verb","Subtle Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_admin_mod_antag_rep(client/C in GLOB.clients, var/operation)
+	set category = "Special Verbs"
+	set name = "Modify Antagonist Reputation"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/msg = ""
+	var/log_text = ""
+
+	if(operation == "zero")
+		log_text = "Set to 0"
+		SSpersistence.antag_rep -= C.ckey
+	else
+		var/prompt = "Please enter the amount of reputation to [operation]:"
+
+		if(operation == "set")
+			prompt = "Please enter the new reputation value:"
+
+		msg = input("Message:", prompt) as num
+
+		if (!msg)
+			return
+
+		var/ANTAG_REP_MAXIMUM = CONFIG_GET(number/antag_rep_maximum)
+
+		if(operation == "set")
+			log_text = "Set to [num2text(msg)]"
+			SSpersistence.antag_rep[C.ckey] = max(0, min(msg, ANTAG_REP_MAXIMUM))
+		else if(operation == "add")
+			log_text = "Added [num2text(msg)]"
+			SSpersistence.antag_rep[C.ckey] = min(SSpersistence.antag_rep[C.ckey]+msg, ANTAG_REP_MAXIMUM)
+		else if(operation == "subtract")
+			log_text = "Subtracted [num2text(msg)]"
+			SSpersistence.antag_rep[C.ckey] = max(SSpersistence.antag_rep[C.ckey]-msg, 0)
+		else
+			to_chat(src, "Invalid operation for antag rep modification: [operation] by user [key_name(usr)]")
+			return
+
+		if(SSpersistence.antag_rep[C.ckey] <= 0)
+			SSpersistence.antag_rep -= C.ckey
+
+	log_admin("[key_name(usr)]: Modified [key_name(C)]'s antagonist reputation [log_text]")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)]: Modified [key_name(C)]'s antagonist reputation ([log_text])</span>")
+	SSblackbox.add_details("admin_verb", "Modify Antagonist Reputation") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/proc/cmd_admin_world_narrate()
 	set category = "Special Verbs"
 	set name = "Global Narrate"

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -13,6 +13,7 @@ Assistant
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit = /datum/outfit/job/assistant
+	antag_rep = 3
 
 
 /datum/job/assistant/get_access()

--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -16,6 +16,7 @@ Blueshield
 	exp_requirements = 600 //10 hours
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are a bodyguard for heads of staff. You are not a security officer. Do not do security's job."
+	antag_rep = 14
 
 	outfit = /datum/outfit/job/blueshield
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -15,6 +15,7 @@ Captain
 	minimal_player_age = 14
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 20
 
 	outfit = /datum/outfit/job/captain
 
@@ -69,6 +70,7 @@ Head of Personnel
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are not a security officer. Do not do their job."
+	antag_rep = 18
 
 	outfit = /datum/outfit/job/hop
 

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -18,6 +18,7 @@ Quartermaster
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
 	special_notice = "The Quartermaster is now a Head of Staff. Act like it."
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/quartermaster
 
@@ -48,6 +49,7 @@ Cargo Technician
 	spawn_positions = 2
 	supervisors = "the quartermaster"
 	selection_color = "#dcba97"
+	antag_rep = 10
 
 	outfit = /datum/outfit/job/cargo_tech
 
@@ -76,6 +78,7 @@ Shaft Miner
 	spawn_positions = 3
 	supervisors = "the quartermaster"
 	selection_color = "#dcba97"
+	antag_rep = 10
 
 	outfit = /datum/outfit/job/miner
 
@@ -154,6 +157,7 @@ Bartender
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	antag_rep = 8
 
 	outfit = /datum/outfit/job/bartender
 
@@ -186,6 +190,7 @@ Cook
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	antag_rep = 8
 	var/cooks = 0 //Counts cooks amount
 
 	outfit = /datum/outfit/job/cook
@@ -234,6 +239,7 @@ Botanist
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	antag_rep = 8
 
 	outfit = /datum/outfit/job/botanist
 
@@ -272,6 +278,7 @@ Janitor
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	antag_rep = 8
 	var/global/janitors = 0
 
 	outfit = /datum/outfit/job/janitor

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -12,6 +12,7 @@ Clown
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	special_notice = "There is a difference between harmless pranks and griefing. Know it."
+	antag_rep = 4
 
 	outfit = /datum/outfit/job/clown
 
@@ -73,6 +74,7 @@ Mime
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	special_notice = "There is a difference between harmless pranks and griefing. Know it."
+	antag_rep = 4
 
 	outfit = /datum/outfit/job/mime
 
@@ -123,6 +125,7 @@ Curator
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	antag_rep = 5
 
 	outfit = /datum/outfit/job/curator
 
@@ -170,6 +173,7 @@ Internal Affairs Agent
 	minimal_player_age = 14
 	exp_requirements = 180 //3 hours
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/iaa
 	//Basic access to each department

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -12,6 +12,7 @@ Chaplain
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	antag_rep = 5
 
 	outfit = /datum/outfit/job/chaplain
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -17,6 +17,7 @@ Chief Engineer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
+	antag_rep = 18
 
 	outfit = /datum/outfit/job/ce
 
@@ -75,6 +76,7 @@ Station Engineer
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/engineer
 
@@ -131,6 +133,7 @@ Atmospheric Technician
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/atmos
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -48,6 +48,9 @@
 	var/exp_type = ""
 	var/exp_type_department = ""
 
+	//The amount of good boy points playing this role will earn you towards a higher chance to roll antagonist next round
+	var/antag_rep = 0
+
 	//A special, very large and noticeable message for certain roles reminding them of something important. Ex: "Blueshields are not security"
 	var/special_notice = ""
 

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -17,6 +17,7 @@ Chief Medical Officer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
+	antag_rep = 18
 
 	outfit = /datum/outfit/job/cmo
 
@@ -58,6 +59,7 @@ Medical Doctor
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/doctor
 
@@ -95,6 +97,7 @@ Chemist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/chemist
 
@@ -131,6 +134,7 @@ Geneticist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/geneticist
 
@@ -167,6 +171,7 @@ Virologist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/virologist
 
@@ -201,6 +206,7 @@ Virologist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/paramedic
 

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -17,6 +17,7 @@ Research Director
 	exp_type_department = EXP_TYPE_SCIENCE
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 18
 
 	outfit = /datum/outfit/job/rd
 
@@ -73,6 +74,7 @@ Scientist
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/scientist
 
@@ -108,6 +110,7 @@ Roboticist
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 12
 
 	outfit = /datum/outfit/job/roboticist
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -23,6 +23,7 @@ Head of Security
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
+	antag_rep = 18
 
 	outfit = /datum/outfit/job/hos
 
@@ -75,6 +76,7 @@ Warden
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 16
 
 	outfit = /datum/outfit/job/warden
 
@@ -127,6 +129,7 @@ Detective
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance."
+	antag_rep = 10
 
 	outfit = /datum/outfit/job/detective
 
@@ -177,6 +180,7 @@ Security Officer
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 15
 
 	outfit = /datum/outfit/job/security
 
@@ -304,6 +308,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 10
 
 	outfit = /datum/outfit/job/brig_phys
 

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -14,6 +14,7 @@ AI
 	minimal_player_age = 30
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 20
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	return H.AIize(FALSE)
@@ -46,6 +47,7 @@ Cyborg
 	minimal_player_age = 21
 	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
+	antag_rep = 16
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)
 	return H.Robotize(FALSE, FALSE)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -14,7 +14,7 @@ AI
 	minimal_player_age = 30
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
+	antag_rep = 10
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	return H.AIize(FALSE)
@@ -47,7 +47,7 @@ Cyborg
 	minimal_player_age = 21
 	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 16
+	antag_rep = 8
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)
 	return H.Robotize(FALSE, FALSE)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -51,3 +51,5 @@
 	var/icon_render_key = ""
 	var/static/list/limb_icon_cache = list()
 	var/has_bones = FALSE//whether carbon has breakable bones. Species overrides this var on humans.
+
+	var/latest_id_job //the assignment on the last equipped ID with their name

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -234,6 +234,21 @@ TRAITOR_OBJECTIVES_AMOUNT 2
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS
 
+## Comment this out to disable the antagonist reputation system. This system rewards players who participate in the game instead of greytiding by giving them slightly higher odds to
+## roll antagonist in subsequent rounds until they get it.
+##
+## For details See the comments for /datum/game_mode/proc/antag_pick in code/game/gamemodes/game_mode.dm
+# USE_ANTAG_REP
+
+## The maximum amount of antagonist reputation tickets a player can bank (not use at once)
+ANTAG_REP_MAXIMUM 200
+
+## The default amount of tickets all users use while rolling
+DEFAULT_ANTAG_TICKETS 100
+
+## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
+MAX_TICKETS_PER_ROLL 100
+
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 #SHOW_GAME_TYPE_ODDS
 


### PR DESCRIPTION
:cl: avosirenfal, ported by ike709
add: Every round you finish alive and active, your chances of rolling antag increases until the odds are double and then it resets once you roll antag.
add: Certain jobs buff your antag chances more than others, usually based on the job's importance. AKA don't play assistant if you want to frequently be an antag.
/:cl:

Ports https://github.com/tgstation/tgstation/pull/35485/

Values for each job are different from TG and subject to maintainer review:
```
AI - 10
Captain - 20
Chief Engineer - 18
Chief Medical Officer - 18
Detective - 10
Head of Personnel - 18
Head of Security - 18
Research Director - 18
Security Officer - 15
Warden - 16
Atmospheric Technician - 12
Botanist - 8
Chemist - 12
Cook - 8
Cyborg - 8
Geneticist - 12
Janitor - 8
Internal Affairs Agent - 12
Medical Doctor - 12
Quartermaster - 12
Roboticist - 12
Scientist - 12
Shaft Miner - 10
Station Engineer - 12
Virologist - 12
Bartender - 8
Cargo Technician - 10
Chaplain - 5
Clown - 4
Curator - 5
Mime - 4
Blueshield - 14
Paramedic - 12
Brig Physician - 10
Assistant - 3
```

I'm accepting suggestions for ways of displaying the values to players without breaking immersion. Just shove it on the wiki? It'd be lame, but easy.

EDIT:
>I refactored how the code works and also added some job checks. Here's how it works now, checked at round end:
>Roll antag? Points removed.
Don't survive the round or go AFK? Zero points.
Get an ID change from lower point to higher point job? You get your original job points.
Get an ID change from higher point job to lower point job? You get the lower point job points. That's how being demoted or being a prisoner at roundend handles this.

~~DNM pending a fix port from TG.~~ Ported #36188