### PR TITLE
Fixes RCD airlock drone hatches

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -247,6 +247,8 @@
 			else
 				A.req_access = A.electronics.accesses
 			A.autoclose = TRUE
+			if(A.has_hatch)
+				A.setup_hatch()
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			if(istype(src, baseturf))


### PR DESCRIPTION
:cl: ike709
fix: RCD airlocks no longer have invisible drone hatches.
/:cl:

They worked but had no icon.

wew lad
