### PR TITLE
Sleeper Agent/Double Agent Tweaks

### DIFF
--- a/code/datums/antagonists/datum_sleeper_agent.dm
+++ b/code/datums/antagonists/datum_sleeper_agent.dm
@@ -305,7 +305,7 @@
 	to_chat(owner.current, "<span class='userdanger'>You are the [special_role].</span>")
 	if(this.syndicate)
 		to_chat(owner.current, "<span class='userdanger'>Your target has been framed for [crime], and you have been tasked with eliminating them to prevent them defending themselves in court.</span>")
-		to_chat(owner.current, "<B><font size=5 color=red>Any damage you cause will be a further embarrassment to Nanotrasen, so you have no limits on collateral damage.</font></B>")
+		to_chat(owner.current, "<B><font size=5 color=red>While you are an agent of the Syndicate, there are more of our agents out there. To prevent unnecessary loss of these known unknowns, keep collateral damage to a minimum.</font></B>")
 		to_chat(owner.current, "<span class='userdanger'> You have been provided with a standard uplink to accomplish your task. </span>")
 	else
 		to_chat(owner.current, "<span class='userdanger'>Your target is suspected of [crime], and you have been tasked with eliminating them by any means necessary to avoid a costly and embarrassing public trial.</span>")

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -3,7 +3,7 @@
 	var/list/late_joining_list = list()
 
 /datum/game_mode/traitor/sleeper_agent
-	name = "Sleeper Agents"
+	name = "sleeper agents"
 	config_tag = "sleeper_agent"
 	required_players = 25
 	required_enemies = 4

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -6,12 +6,12 @@
 	name = "Sleeper Agents"
 	config_tag = "sleeper_agent"
 	required_players = 25
-	required_enemies = 5
-	recommended_enemies = 8
+	required_enemies = 4
+	recommended_enemies = 6
 	reroll_friendly = 0
 	traitor_name = "Nanotrasen Sleeper Agent"
 
-	traitors_possible = 10 //hard limit on traitors if scaling is turned off
+	traitors_possible = 8 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors
 	antag_datum = ANTAG_DATUM_SLEEPER_AGENT
 


### PR DESCRIPTION
:cl: 
tweak: Change the Sleeper Agents' objectives to prohibit collateral damage.
balance: Sleeper Agents will now have lower numbers when present.
/:cl:

Less Murderbone
SLIGHTLY Less chaos