### PR TITLE
Clown Fixes. Honk!

### DIFF
--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -84,15 +84,15 @@
 /datum/antagonist/traitor/apply_innate_effects()
 	if(owner.assigned_role == "Clown")
 		var/mob/living/carbon/human/traitor_mob = owner.current
-		if(traitor_mob&&istype(traitor_mob))
-			if(!silent) 
+		if(traitor_mob && istype(traitor_mob))
+			if(!silent)
 				to_chat(traitor_mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 			traitor_mob.dna.remove_mutation(CLOWNMUT)
 
 /datum/antagonist/traitor/remove_innate_effects()
 	if(owner.assigned_role == "Clown")
 		var/mob/living/carbon/human/traitor_mob = owner.current
-		if(traitor_mob&&istype(traitor_mob))
+		if(traitor_mob && istype(traitor_mob) && traitor_mob.mind.special_role != "traitor")
 			traitor_mob.dna.add_mutation(CLOWNMUT)
 
 /datum/antagonist/traitor/on_removal()
@@ -327,4 +327,3 @@
 	if (equipped_slot)
 		where = "In your [equipped_slot]"
 	to_chat(mob, "<BR><BR><span class='info'>[where] is a folder containing <b>secret documents</b> that another Syndicate group wants. We have set up a meeting with one of their agents on station to make an exchange. Exercise extreme caution as they cannot be trusted and may be hostile.</span><BR>")
-

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -309,6 +309,7 @@ GLOBAL_LIST_EMPTY(mutations_list)
 	if(..())
 		return
 	owner.disabilities &= ~CLUMSY
+	to_chat(owner, "<span class='danger'>You no longer feel funny.</span>")
 
 /datum/mutation/human/tourettes
 	name = "Tourettes Syndrome"

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -58,7 +58,7 @@ Clown
 		return
 
 	H.dna.add_mutation(CLOWNMUT)
-
+	H.dna.add_mutation(WACKY)
 /*
 Mime
 */


### PR DESCRIPTION
:cl:
add: Clowns now talk in sans font
add: Text for losing clumsy disability
fix: Traitor clowns are no longer clumsy. Be afraid.
/:cl:

[why]: 
Clown Font: Why not. It's funny
Text for losing Clumsy: It's needed to make sure that you are no longer going to shoot yourself
Traitor Clown fix: Consistency in text. `"Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself."`. I understand there's the clown reverse revolver, but if that's the intent, why does it attempt to remove it?

Just weird.
