### PR TITLE
Fixes prefs breaking after reentering the game

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -227,6 +227,8 @@ GLOBAL_LIST(external_rsc_urls)
 	if(!prefs)
 		prefs = new /datum/preferences(src)
 		GLOB.preferences_datums[ckey] = prefs
+	if(!prefs.parent)
+		prefs.parent = src
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	fps = prefs.clientfps

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -160,18 +160,20 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	user << browse_rsc(fakeicon, "fakeicon.png")
 	datspecies += "<center>"
 	datspecies += "<img src=fakeicon.png width=[fakeicon.Width()] height=[fakeicon.Height()]><BR>"
+	var/required = S.required_playtime_remaining(parent)
 	if(pref_species.id == species_looking_at)
 		datspecies += "Set Species "
+	else if(required)
+		datspecies += "<span class='linkOff'>Set Species</span>"
 	else
 		datspecies += "<a href='?_src_=prefs;setspecies=[species_looking_at];task=species'>Set Species</a> "
 	datspecies += "<a href='?_src_=prefs;preference=job;task=close'>Done</a><BR>"
-	var/required = S.required_playtime_remaining(parent)
 	if(required)
 		datspecies += "<span class='warning'><font color='red'>[required] more to unlock!</font></span>"
 	datspecies += "</center></th></tr></table></div>"
 
 	user << browse(null, "window=preferences")
-	var/datum/browser/popup = new(user, "speciespick", "<div align='center'>Species Pick</div>", 700, 230)
+	var/datum/browser/popup = new(user, "speciespick", "<div align='center'>Species Pick</div>", 700, 350)
 	popup.set_window_options("can_close=0")
 	popup.set_content(datspecies)
 	popup.open(0)


### PR DESCRIPTION
Turns out if you deleted a client and then reconnected, the prefs wouldn't properly update which client they're related to. Because the species code was doing weird things, that'd break stuff.

It's all fixed now, hopefully.

Also makes the pref screen a tiny bit prettier.
:tada:

fixes #698 