### PR TITLE
Makes Asteroid with Rockets require emagging the console

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -93,7 +93,7 @@
 /datum/map_template/shuttle/emergency/meteor/prerequisites_met(mob/user)
 	if("emagged" in SSshuttle.shuttle_purchase_requirements_met)
 		return TRUE
-	to_chat(user, "<span class='notice'>The console blocks the purchase of that shuttle.</span>")
+	to_chat(user, "<span class='notice'>Central Command has deemed this shuttle too dangerous for general usage. The console's safeties prevent its purchase.</span>")
 	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -86,9 +86,15 @@
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
-	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
+	description = "A hollowed out asteroid with engines strapped to it. Due to its size and poor navigation protocols, this 'shuttle' will damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = -5000
+
+/datum/map_template/shuttle/emergency/meteor/prerequisites_met(mob/user)
+	if("emagged" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	to_chat(user, "<span class='notice'>The console blocks the purchase of that shuttle.</span>")
+	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -401,6 +401,7 @@
 	if(emagged)
 		return
 	emagged = TRUE
+	SSshuttle.shuttle_purchase_requirements_met |= "emagged"
 	if(authenticated == 1)
 		authenticated = 2
 	to_chat(user, "<span class='danger'>You scramble the communication routing circuits!</span>")

--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -18,9 +18,9 @@ _maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
 #_maps/shuttles/emergency_clown.dmm
 #_maps/shuttles/emergency_cramped.dmm
-#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_goon.dmm
-#_maps/shuttles/emergency_luxury.dmm
+_maps/shuttles/emergency_luxury.dmm
 #_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm


### PR DESCRIPTION
:cl: 
add: Asteroid with Engines requires you to emag the coms console before purchase now
/:cl:

also I know it's a config update but for the love of god please also disable imfedupwiththisworld and the luxury shuttle