### PR TITLE
Tweaked MetaStation genpop.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -210,11 +210,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-03";
 	layer = 4.1
@@ -231,11 +226,6 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aaD" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/twohanded/required/kirbyplants{
 	layer = 4.1
 	},
@@ -271,21 +261,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/top{
 	dir = 4
 	},
@@ -302,16 +277,6 @@
 /area/security/prison)
 "aaJ" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/bottom{
 	dir = 8
 	},
@@ -320,11 +285,6 @@
 "aaK" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/glowshroom,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaL" = (
@@ -359,11 +319,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -485,21 +440,11 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abi" = (
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -509,11 +454,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abj" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/twentythreeXtwentythree,
@@ -524,18 +464,8 @@
 /obj/structure/table,
 /obj/item/folder,
 /obj/item/paper/guides/jobs/hydroponics,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/pen,
 /obj/item/storage/crayons,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -596,19 +526,14 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/barber{
-	dir = 8
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 1
 	},
 /area/security/prison)
 "abs" = (
-/obj/machinery/washing_machine,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/barber{
-	dir = 8
+/obj/machinery/cryopod,
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 1
 	},
 /area/security/prison)
 "abt" = (
@@ -703,11 +628,6 @@
 /area/security/prison)
 "abF" = (
 /obj/structure/table,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -742,27 +662,12 @@
 /area/security/prison)
 "abJ" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/barber{
-	dir = 8
-	},
+/turf/open/floor/plasteel/whitegreen/side,
 /area/security/prison)
 "abK" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
 /obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/barber{
-	dir = 8
-	},
+/obj/machinery/cryopod,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/security/prison)
 "abL" = (
 /turf/open/floor/plating,
@@ -918,11 +823,6 @@
 /area/security/prison)
 "aca" = (
 /obj/structure/table,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/toy/cards/deck,
 /obj/item/toy/cards/deck,
 /obj/effect/decal/cleanable/dirt,
@@ -1051,7 +951,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "acr" = (
 /obj/structure/cable/yellow{
@@ -1089,11 +989,6 @@
 /area/security/prison)
 "acu" = (
 /obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
 /turf/open/floor/plasteel,
@@ -1200,7 +1095,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "acE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1222,13 +1117,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_y = -28;
-	prison_radio = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Prison Chamber";
 	dir = 1;
@@ -1244,11 +1132,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acI" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom{
 	dir = 6
 	},
@@ -1697,6 +1580,13 @@
 	network = list("SS13","Prison")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher{
+	desc = "A high power wall-mounted flashbulb device.";
+	id = "genpop_flash";
+	name = "genpop flash";
+	pixel_x = -24;
+	range = 3
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adv" = (
@@ -1728,7 +1618,7 @@
 	pixel_y = 2;
 	req_one_access_txt = "2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "adx" = (
 /obj/structure/bed,
@@ -1919,7 +1809,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "adP" = (
 /obj/structure/table,
@@ -1943,11 +1833,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adS" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/bottom{
 	dir = 4
 	},
@@ -2412,15 +2297,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2435,6 +2319,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2463,6 +2350,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2487,6 +2377,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2517,13 +2410,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2538,6 +2429,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2562,6 +2456,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2579,6 +2476,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2621,6 +2524,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2656,6 +2562,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -2671,6 +2580,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/top{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -3023,16 +2936,12 @@
 "afG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
 /area/security/prison)
 "afH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -3527,8 +3436,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "agE" = (
-/obj/structure/closet/secure_closet/genpop,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
 /area/security/prison)
 "agF" = (
 /obj/structure/cable/yellow{
@@ -4365,11 +4275,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "air" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -4393,11 +4298,6 @@
 /obj/machinery/door/airlock/glass_security{
 	name = "Security E.V.A. Storage";
 	req_access_txt = "3"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5154,6 +5054,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/top{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akh" = (
@@ -5357,6 +5258,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akz" = (
@@ -7397,10 +7299,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -7408,6 +7306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aot" = (
@@ -91236,11 +91135,6 @@
 /turf/closed/wall,
 /area/medical/cryo)
 "dER" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom{
 	dir = 6
 	},
@@ -91257,11 +91151,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dET" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
 /turf/open/floor/plasteel,
@@ -91304,11 +91193,13 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dEY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dEZ" = (
@@ -93937,6 +93828,208 @@
 	},
 /turf/closed/wall/r_wall,
 /area/aisat)
+"dLg" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 2
+	},
+/area/security/prison)
+"dLh" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"dLi" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"dLj" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"dLk" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"dLl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/brig)
+"dLm" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLn" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLo" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLp" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLq" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLr" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLs" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLt" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLu" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLv" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLw" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLx" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLy" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLz" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLA" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLB" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLC" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLD" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLE" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLF" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLG" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLH" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLI" = (
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLJ" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dLK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/brig)
+"dLL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/brig)
+"dLM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/bottom,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/top,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 
 (1,1,1) = {"
 aaa
@@ -115087,10 +115180,10 @@ aax
 aax
 aax
 aax
-aaa
-aaa
-dDW
-aaa
+aax
+aax
+aax
+aax
 aaa
 aaf
 aaa
@@ -115331,7 +115424,7 @@ aaf
 aaa
 aaa
 aaf
-aay
+aax
 abh
 abA
 abY
@@ -115343,13 +115436,13 @@ adN
 aej
 aeK
 afF
+dLh
+dLm
+dLu
+dLC
 aax
-aax
-aaa
-dDW
 aaa
 aaa
-aaf
 aaa
 dne
 dnu
@@ -115601,12 +115694,12 @@ aax
 aeL
 afV
 agE
+dLn
+dLv
+dLD
 aax
 aaa
-dDW
 aaa
-aaa
-aaf
 aaf
 aip
 ana
@@ -115857,13 +115950,13 @@ adO
 abe
 aeM
 afH
-agF
-afW
-dDW
-dDW
-dDW
-aaf
-aaf
+agE
+dLo
+dLw
+dLE
+aax
+aaa
+aaa
 aaa
 dne
 dnd
@@ -116102,25 +116195,25 @@ aaf
 aaf
 aaf
 aaf
-aay
+aax
 abk
-abC
-dIB
-acr
-acE
+aaR
+abE
+aaR
+abE
 adb
 aaR
 dEU
 aem
 aeN
 afI
-agE
+dLi
+dLp
+dLx
+dLF
 aax
 aaa
-dDW
 aaa
-aaa
-aaf
 aaa
 dne
 dne
@@ -116363,21 +116456,21 @@ aax
 abl
 abD
 abE
-acs
+aaR
 acF
 abe
 adt
 adP
 abe
 aeO
-afJ
+afV
+dLj
+dLq
+dLy
+dLG
 aax
-aax
-aaa
-dDW
 aaa
 aaa
-aaf
 aaa
 aaa
 dne
@@ -116614,13 +116707,13 @@ aaa
 aaa
 aax
 aax
-aaF
+aax
 aax
 aax
 abm
 aaR
 aaR
-aaI
+abE
 acG
 abe
 abe
@@ -116628,13 +116721,13 @@ abe
 abe
 aeP
 afV
-dJj
+agE
+dLr
+dLz
+dLH
 aax
 aaa
-dDW
 aaa
-aaa
-aaf
 dne
 dne
 dne
@@ -116877,21 +116970,21 @@ aax
 abn
 aaR
 acc
-aaI
+abE
 acH
 dIC
 adu
 adR
-aaR
-aeM
-afL
-agF
-afW
-dDW
-dDW
-dDW
-aaf
-aaf
+dIC
+dLg
+afV
+agE
+dLs
+dLA
+dLI
+aax
+aaa
+aaa
 dne
 alL
 anb
@@ -117126,29 +117219,29 @@ aaa
 aaa
 aaf
 aaf
-aay
+aax
 aaB
 aaH
 aaQ
-aba
-abo
+agL
+abE
 abF
 aca
-act
+aaR
 acI
 add
-adv
+dES
 adS
-adv
+add
 aeR
 afV
-agE
+dLk
+dLt
+dLB
+dLJ
 aax
 aaa
 aaa
-aaa
-aaf
-aaf
 dne
 alL
 anc
@@ -117384,7 +117477,7 @@ aaa
 aaf
 aaa
 aax
-aaC
+aaR
 dER
 dES
 abb
@@ -117396,13 +117489,13 @@ acJ
 dID
 adw
 dIE
-abE
+dID
 aeS
 afM
 abe
-ajm
-aiq
-ajm
+ahx
+ahx
+ahx
 ajm
 ajm
 ajm
@@ -117640,15 +117733,15 @@ aaa
 aaa
 aaa
 aaa
-aay
+aax
 aaD
 aaJ
 abE
-aay
-acw
+agL
+abE
 acc
 acc
-aaI
+abE
 acK
 abe
 abe
@@ -117903,9 +117996,9 @@ aaK
 aaT
 aax
 abq
-abI
-abC
-acw
+abE
+aaR
+abE
 acL
 abe
 adx
@@ -118156,7 +118249,7 @@ aaf
 aaf
 aax
 aax
-aaL
+aax
 aax
 aax
 abr
@@ -118168,7 +118261,7 @@ ade
 abE
 dEU
 aeo
-aeV
+aeR
 afP
 abe
 ahw
@@ -118415,7 +118508,7 @@ aaa
 aaf
 aaa
 aaa
-aay
+aax
 abs
 abK
 ace
@@ -118686,7 +118779,7 @@ aeX
 afL
 dEa
 ahy
-dEi
+aiu
 ajn
 dEC
 aiu
@@ -118941,16 +119034,16 @@ acf
 acy
 aeY
 afG
-dEW
+dLl
 dEX
 dEY
-dEW
-aiv
+dLK
+dLL
 dEY
 dEY
 aky
 akg
-ani
+dLM
 aos
 apF
 apF


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/202160/37732600-6607ff48-2d3d-11e8-89a5-86c0892a53bf.png)

- Removed windows
- Added cryo
- Added more lockers
- Added disposals bin
- Added second set of turnstiles

:cl: AndrewMontagne
tweak: MetaStation genpop is now a wee bit more greytide-resistant.
/:cl: