### PR TITLE
Event rebalance (aka statistics is hard)

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/brand_intelligence
 	name = "Brand Intelligence"
 	typepath = /datum/round_event/brand_intelligence
-	weight = 5
+	weight = 8
 
 	min_players = 15
 	max_occurrences = 1

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/camera_failure
 	name = "Camera Failure"
 	typepath = /datum/round_event/camera_failure
-	weight = 100
+	weight = 102
 	max_occurrences = 20
 	alertadmins = 0
 

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -1,10 +1,10 @@
 /datum/round_event_control/carp_migration
 	name = "Carp Migration"
 	typepath = /datum/round_event/carp_migration
-	weight = 15
-	min_players = 2
+	weight = 20
+	min_players = 8
 	earliest_start = 6000
-	max_occurrences = 6
+	max_occurrences = 5
 
 /datum/round_event/carp_migration
 	announceWhen	= 3
@@ -24,5 +24,3 @@
 				new /mob/living/simple_animal/hostile/carp(C.loc)
 			else
 				new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)
-
-

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
 	min_players = 10
-	weight = 5
+	weight = 7
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/space_dust
 	name = "Minor Space Dust"
 	typepath = /datum/round_event/space_dust
-	weight = 200
+	weight = 203
 	max_occurrences = 1000
 	earliest_start = 0
 	alertadmins = 0

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -4,7 +4,7 @@
 	earliest_start = 6000
 	max_occurrences = 3
 	min_players = 5
-	weight = 30
+	weight = 40
 	alertadmins = 1
 
 /datum/round_event/electrical_storm

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/falsealarm
 	name 			= "False Alarm"
 	typepath 		= /datum/round_event/falsealarm
-	weight			= 20
+	weight			= 25
 	max_occurrences = 5
 
 /datum/round_event_control/falsealarm/canSpawnEvent(players_amt, gamemode)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -4,7 +4,7 @@
 /datum/round_event_control/ion_storm
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
-	weight = 15
+	weight = 18
 	min_players = 2
 
 /datum/round_event/ion_storm

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/mass_hallucination
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
-	weight = 7
+	weight = 9
 	max_occurrences = 2
 	min_players = 1
 

--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/meteor_wave/meaty
 	name = "Meteor Wave: Meaty"
 	typepath = /datum/round_event/meteor_wave/meaty
-	weight = 2
+	weight = 1
 	max_occurrences = 1
 
 /datum/round_event/meteor_wave/meaty

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 4
+	weight = 6
 	min_players = 5
 	max_occurrences = 3
 
@@ -50,7 +50,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 2
+	weight = 3
 	min_players = 5
 	max_occurrences = 3
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/grey_tide
 	max_occurrences = 2
 	min_players = 5
-	weight = 3
+	weight = 5
 
 /datum/round_event/grey_tide
 	announceWhen = 50

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/spider_infestation
 	name = "Spider Infestation"
 	typepath = /datum/round_event/spider_infestation
-	weight = 5
+	weight = 10
 	max_occurrences = 1
 	min_players = 15
 

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -2,7 +2,7 @@
 	name = "Wormholes"
 	typepath = /datum/round_event/wormholes
 	max_occurrences = 3
-	weight = 2
+	weight = 3
 	min_players = 2
 
 


### PR DESCRIPTION
So there were some merged PRs which had the best of intentions. (IE: Lower chaos levels, decreasing "round ending" style events).

However, due to the maths of it, and lacking a full understanding of the system, what actually happened is it increased them, due to proportionality & weight totals.

I've gone through and done the maths on all the changes which you can find here: https://docs.google.com/spreadsheets/d/17BmqzKJp6z7vYrBY5GvHUXQQdDXrmATzJFeMBhsBi7Q/edit?usp=sharing

This includes this PR's proposed changes... as I'm certain the original intention WASN'T to increase the frequency of blobs and syndicate shocktroops etc.

This also reverts an old PR of mine back from our testing days - because it was rough, when playing on Omega. In future it'd be nice to have an event system that tweaks based on map played as well. But thats for the future.

:cl: Purpose
tweak: Rebalanced the events system.
/ :cl: