### PR TITLE
Space Hotel Staff and Security spawn with their ID Cards now

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2899,12 +2899,6 @@
 /area/ruin/space/has_grav/hotel/workroom)
 "hE" = (
 /obj/structure/table,
-/obj/item/card/id/away/hotel,
-/obj/item/card/id/away/hotel,
-/obj/item/card/id/away/hotel,
-/obj/item/card/id/away/hotel,
-/obj/item/card/id/away/hotel,
-/obj/item/card/id/away/hotel,
 /turf/open/floor/plasteel/black,
 /area/ruin/space/has_grav/hotel/workroom)
 "hF" = (
@@ -4510,7 +4504,6 @@
 /area/ruin/space/has_grav/hotel/pool)
 "lS" = (
 /obj/structure/table,
-/obj/item/card/id/away/hotel/securty,
 /turf/open/floor/plasteel/darkred,
 /area/ruin/space/has_grav/hotel/security)
 "lT" = (
@@ -7269,7 +7262,7 @@ hW
 ih
 ih
 fi
-iX
+hQ
 hf
 cQ
 cQ

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -309,13 +309,14 @@
 	r_pocket = /obj/item/device/radio/off
 	back = /obj/item/storage/backpack
 	implants = list(/obj/item/implant/mindshield)
+	id = /obj/item/card/id/away/hotel
 
 /obj/effect/mob_spawn/human/hotel_staff/security
 	name = "hotel security sleeper"
 	mob_name = "hotel security memeber"
 	outfit = /datum/outfit/hotelstaff/security
-	flavour_text = "You are a peacekeeper assigned to this hotel to protect the intrests of the company while keeping the peace between \
-		guests and the staff.Do <font size=6><b>NOT</b></font> leave the hotel, as that is grounds for contract termination."
+	flavour_text = "You are a peacekeeper assigned to this hotel to protect the interests of the company while keeping the peace between \
+		guests and 	staff. Do <font size=6><b>NOT</b></font> leave the hotel, as that is grounds for contract termination."
 	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests, non-lethal force heavily advised if possible."
 
 /datum/outfit/hotelstaff/security
@@ -326,6 +327,8 @@
 	head = /obj/item/clothing/head/helmet/blueshirt
 	back = /obj/item/storage/backpack/security
 	belt = /obj/item/storage/belt/security/full
+	implants = list(/obj/item/implant/mindshield)
+	id = /obj/item/card/id/away/hotel/securty
 
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))


### PR DESCRIPTION
🆑 lorwp
tweak: Hotel staff and security Spawn with their IDs now, instead of picking them up after they spawn
/:cl:

Closes #744 which was probably due to the IDs being stolen before the Hotel Staff/Security could spawn. Now both of them spawn with their relevant ID Cards.

It is possible to also put their names on the ID cards properly instead of using the premade cards, though i avoided this to stop them from being confused with Station Crew.

Also adds a mindshield implant to Hotel Security to keep them consistent with Hotel Staff. Not sure why staff have a mindshield in the first place, but at least it's consistent now.