### PR TITLE
Add Runic golems to the Magic Mirror blacklist

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -89,7 +89,7 @@
 	name = "magic mirror"
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
-	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombie")
+	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombie", "runic golem")
 	var/list/choosable_races = list()
 
 /obj/structure/mirror/magic/New()


### PR DESCRIPTION
:cl:
fix: Wizards can no longer become Runic golems with their magic mirror and phase into Centcom anymore
/:cl:

Resolves #611. `/obj/structure/mirror/magic/badmin` mirrors still allow them because admemes