### PR TITLE
Adds Keycard Auths to QM Offices on Box and Meta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -28387,7 +28387,6 @@
 "bor" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
-
 /obj/item/razor,
 /turf/open/floor/plasteel/black,
 /area/science/robotics/lab)
@@ -30512,7 +30511,6 @@
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
-
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bsV" = (
@@ -32945,6 +32943,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = 0;
+	pixel_y = -25
+	},
 /turf/open/floor/plasteel/brown{
 	dir = 2
 	},
@@ -34242,7 +34244,6 @@
 /area/medical/sleeper)
 "bBc" = (
 /obj/structure/table,
-
 /obj/item/razor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52646,7 +52647,6 @@
 /area/engine/engineering)
 "cpF" = (
 /obj/structure/table/optable,
-
 /turf/open/floor/mineral/titanium,
 /area/shuttle/syndicate)
 "cpG" = (
@@ -61634,7 +61634,6 @@
 /area/shuttle/syndicate)
 "cLl" = (
 /obj/structure/table/optable,
-
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -84368,7 +84367,7 @@ bxu
 byA
 bzR
 byd
-bxx
+bxu
 aaa
 cTg
 cTg

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20476,6 +20476,9 @@
 "aNO" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/top,
+/obj/machinery/keycard_auth{
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel/brown{
 	dir = 9
 	},
@@ -115438,8 +115441,8 @@ aeK
 afF
 dLh
 dLm
-dLu
-dLC
+dLp
+dLp
 aax
 aaa
 aaa
@@ -115695,8 +115698,8 @@ aeL
 afV
 agE
 dLn
-dLv
-dLD
+dLn
+dLn
 aax
 aaa
 aaa
@@ -115951,9 +115954,9 @@ abe
 aeM
 afH
 agE
-dLo
-dLw
-dLE
+dLn
+dLn
+dLn
 aax
 aaa
 aaa
@@ -116207,10 +116210,10 @@ dEU
 aem
 aeN
 afI
-dLi
+dLh
 dLp
-dLx
-dLF
+dLp
+dLp
 aax
 aaa
 aaa
@@ -116466,8 +116469,8 @@ aeO
 afV
 dLj
 dLq
-dLy
-dLG
+dLq
+dLq
 aax
 aaa
 aaa
@@ -116722,9 +116725,9 @@ abe
 aeP
 afV
 agE
-dLr
-dLz
-dLH
+dLn
+dLn
+dLn
 aax
 aaa
 aaa
@@ -116979,9 +116982,9 @@ dIC
 dLg
 afV
 agE
-dLs
-dLA
-dLI
+dLn
+dLn
+dLn
 aax
 aaa
 aaa
@@ -117235,10 +117238,10 @@ adS
 add
 aeR
 afV
-dLk
+dLh
 dLt
-dLB
-dLJ
+dLp
+dLp
 aax
 aaa
 aaa
@@ -117490,7 +117493,7 @@ dID
 adw
 dIE
 dID
-aeS
+dLg
 afM
 abe
 ahx
@@ -119037,7 +119040,7 @@ afG
 dLl
 dEX
 dEY
-dLK
+dLl
 dLL
 dEY
 dEY


### PR DESCRIPTION
:cl: lorwp
add: The QM's office on Box and Metastation have Keycard Authentication Devices now
/:cl:

Fixes #660. Omega doesn't get one because the QM doesn't have a office, but i can easily add one if wanted.

Box:
![boxstation](https://user-images.githubusercontent.com/8052896/37900985-961fdbfe-313b-11e8-8b5b-1a600f265aad.png)

Meta:
![metastation-manyoumusthaveareallyslowconnectiontoseetheseifeelbadforyouman](https://user-images.githubusercontent.com/8052896/37900993-9c4aec62-313b-11e8-97e6-c726677bf3fb.png)

