### PR TITLE
buffs sarin stun

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -917,7 +917,7 @@
 			if(prob(10))
 				M.confused += 15
 			if(prob(15))
-				M.Stun(1)
+				M.Stun(10)
 				M.emote("scream")
 		if(30 to 60)
 			M.blur_eyes(5)


### PR DESCRIPTION
sarin will now stun for 1 second, as opposed to 1 decisecond, which i suspect was an oversight


:cl: optional name here
add: sarin has been buffed so that the stun effect will now actually apply a stun instead of instantly vanishing

/:cl:
