### PR TITLE
removes other collateral damage line from sleeper agents

### DIFF
--- a/code/datums/antagonists/datum_sleeper_agent.dm
+++ b/code/datums/antagonists/datum_sleeper_agent.dm
@@ -225,7 +225,7 @@
 		if(this.syndicate)
 			to_chat(owner.current,"<span class='userdanger'> All the loyalist agents are dead, and no more is required of you. Die a glorious death, agent. </span>")
 		else
-			to_chat(owner.current,"<span class='userdanger'> All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events. You no longer have any limits on collateral damage.</span>")
+			to_chat(owner.current,"<span class='userdanger'> All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events and die a glorious death.</span>")
 		replace_escape_objective(owner)
 
 /datum/antagonist/traitor/proc/sleeper_agent_process()


### PR DESCRIPTION
:cl:
tweak: Sleeper agents no longer allowed to cause all the collateral damage they want
/:cl:

hugbox, etc
