### PR TITLE
Puts a link to the wiki related to the job upon joining/spawning in

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -440,6 +440,8 @@ SUBSYSTEM_DEF(job)
 		to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
 	if(job.special_notice)
 		to_chat(M, "<span class='userdanger'>[job.special_notice]</span>")
+	if(job.wiki_page)
+		to_chat(M, "<span class='notice'>[CONFIG_GET(string/wikiurl)][job.wiki_page]</span>")
 	if(CONFIG_GET(number/minimal_access_threshold))
 		to_chat(M, "<FONT color='blue'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>")
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -12,9 +12,9 @@ Captain
 	supervisors = "Nanotrasen officials and Space law"
 	selection_color = "#ccccff"
 	req_admin_notify = 1
-	minimal_player_age = 14
+	minimal_player_age = 30
 	exp_requirements = 180
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_COMMAND
 
 	outfit = /datum/outfit/job/captain
 
@@ -66,7 +66,7 @@ Head of Personnel
 	supervisors = "the captain"
 	selection_color = "#ddddff"
 	req_admin_notify = 1
-	minimal_player_age = 10
+	minimal_player_age = 15
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are not a security officer. Do not do their job."

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -15,6 +15,7 @@ Captain
 	minimal_player_age = 30
 	exp_requirements = 180
 	exp_type = EXP_TYPE_COMMAND
+	special_notice = "You may be the Captain of this station, but you are still beholden to The Corporation."
 
 	outfit = /datum/outfit/job/captain
 

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -18,6 +18,7 @@ Quartermaster
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
 	special_notice = "The Quartermaster is now a Head of Staff. Act like it."
+	wiki_page = "Cargo_SOP"
 
 	outfit = /datum/outfit/job/quartermaster
 
@@ -48,6 +49,7 @@ Cargo Technician
 	spawn_positions = 2
 	supervisors = "the quartermaster"
 	selection_color = "#dcba97"
+	wiki_page = "Cargo_Technician"
 
 	outfit = /datum/outfit/job/cargo_tech
 
@@ -76,6 +78,7 @@ Shaft Miner
 	spawn_positions = 3
 	supervisors = "the quartermaster"
 	selection_color = "#dcba97"
+	wiki_page = "Shaft_Miner"
 
 	outfit = /datum/outfit/job/miner
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -12,6 +12,7 @@ Clown
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	special_notice = "There is a difference between harmless pranks and griefing. Know it."
+	wiki_page = "Clown"
 
 	outfit = /datum/outfit/job/clown
 
@@ -73,6 +74,7 @@ Mime
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	special_notice = "There is a difference between harmless pranks and griefing. Know it."
+	wiki_page = "Mime"
 
 	outfit = /datum/outfit/job/mime
 
@@ -170,6 +172,7 @@ Internal Affairs Agent
 	minimal_player_age = 14
 	exp_requirements = 180 //3 hours
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Standard_Operating_Procedure"
 
 	outfit = /datum/outfit/job/iaa
 	//Basic access to each department

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -17,6 +17,7 @@ Chief Engineer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
+	wiki_page = "Engineering_SOP"
 
 	outfit = /datum/outfit/job/ce
 
@@ -76,6 +77,7 @@ Station Engineer
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Station_Engineer"
 
 	outfit = /datum/outfit/job/engineer
 
@@ -133,6 +135,7 @@ Atmospheric Technician
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Atmospheric_Technician"
 
 	outfit = /datum/outfit/job/atmos
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -51,6 +51,9 @@
 	//A special, very large and noticeable message for certain roles reminding them of something important. Ex: "Blueshields are not security"
 	var/special_notice = ""
 
+	// A link to the relevant wiki related to the job. Ex: "Space_law" would link to wiki.blah/Space_law
+	var/wiki_page = ""
+
 //Only override this proc
 //H is usually a human unless an /equip override transformed it
 /datum/job/proc/after_spawn(mob/living/H, mob/M)

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -17,6 +17,7 @@ Chief Medical Officer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
+	wiki_page = "Medical_SOP"
 
 	outfit = /datum/outfit/job/cmo
 
@@ -59,6 +60,7 @@ Medical Doctor
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	wiki_page = "Medical_doctor"
 
 	outfit = /datum/outfit/job/doctor
 
@@ -97,6 +99,7 @@ Chemist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Guide_to_chemistry"
 
 	outfit = /datum/outfit/job/chemist
 
@@ -135,6 +138,7 @@ Geneticist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Guide_to_genetics"
 
 	outfit = /datum/outfit/job/geneticist
 
@@ -172,6 +176,7 @@ Virologist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Infections"
 
 	outfit = /datum/outfit/job/virologist
 
@@ -207,6 +212,7 @@ Virologist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Guide_to_medicine"
 
 	outfit = /datum/outfit/job/paramedic
 

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -17,6 +17,7 @@ Research Director
 	exp_type_department = EXP_TYPE_SCIENCE
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Science_SOP"
 
 	outfit = /datum/outfit/job/rd
 
@@ -110,6 +111,7 @@ Roboticist
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Guide_to_robotics"
 
 	outfit = /datum/outfit/job/roboticist
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -19,10 +19,11 @@ Head of Security
 	supervisors = "the captain"
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
-	minimal_player_age = 14
+	minimal_player_age = 30
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
+	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
 
 	outfit = /datum/outfit/job/hos
 
@@ -76,6 +77,7 @@ Warden
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
 
 	outfit = /datum/outfit/job/warden
 
@@ -171,6 +173,7 @@ Security Officer
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
 
 	outfit = /datum/outfit/job/security
 
@@ -299,6 +302,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance. You are to tend to the medical needs of officers and prisoners."
 
 	outfit = /datum/outfit/job/brig_phys
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -23,7 +23,8 @@ Head of Security
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
-	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
+	special_notice = "Space law is THE LAW. Not a suggestion."
+	wiki_page = "Security_SOP" 
 
 	outfit = /datum/outfit/job/hos
 
@@ -77,7 +78,8 @@ Warden
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
+	special_notice = "Space law is THE LAW. Not a suggestion."
+	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/warden
 
@@ -131,6 +133,7 @@ Detective
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance."
+	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/detective
 
@@ -173,7 +176,8 @@ Security Officer
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	special_notice = "Space law is THE LAW. Not a suggestion. https://wiki.oraclestation.com/wiki/Space_Law"
+	special_notice = "Space law is THE LAW. Not a suggestion."
+	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -23,8 +23,8 @@ Head of Security
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
-	special_notice = "Space law is THE LAW. Not a suggestion."
-	wiki_page = "Security_SOP" 
+	special_notice = "Space Law is THE LAW. Not a suggestion."
+	wiki_page = "Security_SOP"
 
 	outfit = /datum/outfit/job/hos
 
@@ -78,7 +78,7 @@ Warden
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	special_notice = "Space law is THE LAW. Not a suggestion."
+	special_notice = "Space Law is THE LAW. Not a suggestion."
 	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/warden
@@ -176,7 +176,7 @@ Security Officer
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	special_notice = "Space law is THE LAW. Not a suggestion."
+	special_notice = "Space Law is THE LAW. Not a suggestion."
 	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/security


### PR DESCRIPTION
:cl: 
tweak: Captain now requires command experience
add: Relevant wiki links are provided upon joining/spawning in as a job
/:cl:

READ GODDAMNIT, READ.
![nvidia share_2018-03-29_14-47-01](https://user-images.githubusercontent.com/26494679/38112730-15431060-3360-11e8-9810-dbedb278d93e.png)

Also maybe we'll get less shitter Captains with the fact it requires command experience, rather than just.. crew experience.