### PR TITLE
Various OracleUI fixes.

### DIFF
--- a/code/modules/oracle_ui/README.md
+++ b/code/modules/oracle_ui/README.md
@@ -208,6 +208,9 @@ For all viewers, updates the fields in the template via the `updateFields` javaS
 ##### `soft_update_all()`
 For all viewers, updates the content body in the template via the `replaceContent` javaScript function.
 
+##### `change_page(var/newpage)`
+Changes the template to use to draw the page and forces an update to all viewers
+
 ##### `act(label, mob/user, action, list/parameters = list(), class = "", disabled = FALSE`
 Returns a fully formatted hyperlink for the specified user. `label` will be the hyperlink label, `action` and `parameters` are what will be passed to `oui_act`, `class` is any CSS classes to apply to the hyperlink and `disabled` will disable the hyperlink.
 

--- a/code/modules/oracle_ui/hookup_procs.dm
+++ b/code/modules/oracle_ui/hookup_procs.dm
@@ -5,7 +5,7 @@
 	return "Default Implementation"
 
 /datum/proc/oui_canuse(mob/user)
-	if(isobserver(user))
+	if(isobserver(user) && !user.has_unlimited_silicon_privilege)
 		return FALSE
 	return oui_canview(user)
 
@@ -21,6 +21,8 @@
 /atom/oui_canview(mob/user)
 	if(isobserver(user))
 		return TRUE
+	if(user.incapacitated())
+		return FALSE
 	if(isturf(src.loc) && Adjacent(user))
 		return TRUE
 	return FALSE
@@ -31,6 +33,8 @@
 	return ..()
 
 /obj/machinery/oui_canview(mob/user)
+	if(user.has_unlimited_silicon_privilege)
+		return TRUE
 	if(!is_interactable())
 		return FALSE
 	if(iscyborg(user))

--- a/code/modules/oracle_ui/themed.dm
+++ b/code/modules/oracle_ui/themed.dm
@@ -64,6 +64,12 @@ GLOBAL_LIST_EMPTY(oui_file_cache)
 	for(var/viewer in viewers)
 		call_js(viewer, "replaceContent", list(get_inner_content(viewer)))
 
+/datum/oracle_ui/themed/proc/change_page(var/newpage)
+	if(newpage == current_page)
+		return
+	current_page = newpage
+	update_all()
+
 /datum/oracle_ui/themed/proc/act(label, mob/user, action, list/parameters = list(), class = "", disabled = FALSE)
 	if(disabled)
 		return "<a class=\"disabled\">[label]</a>"

--- a/code/modules/oracle_ui/themed.dm
+++ b/code/modules/oracle_ui/themed.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_EMPTY(oui_file_cache)
 	if(newpage == current_page)
 		return
 	current_page = newpage
-	update_all()
+	render_all()
 
 /datum/oracle_ui/themed/proc/act(label, mob/user, action, list/parameters = list(), class = "", disabled = FALSE)
 	if(disabled)

--- a/html/oracle_ui/themes/nano/sui-nano-common.js
+++ b/html/oracle_ui/themes/nano/sui-nano-common.js
@@ -1,5 +1,8 @@
 function replaceContent(body) {
-    document.getElementById('maincontent').innerHTML = body;
+    var maincontent = document.getElementById('maincontent');
+    if(maincontent) {
+      maincontent.innerHTML = body;
+    }
 }
 
 function updateProgressLabels() {


### PR DESCRIPTION
- Allows Admin AI Interact to work with OracleUI.
- Can no longer use UIs while incapacitated.
- Added `change_page` proc.

:cl: AndrewMontagne
add: Fixed issue where OracleUI could be used while incapacitated
/:cl:
