### PR TITLE
Fixed the emergency shuttle quick launch

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -128,7 +128,6 @@
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		minor_announce("The emergency shuttle will launch in \
 			[TIME_LEFT] seconds.", alert=TRUE)
-			[TIME_LEFT] seconds.\n[emag_boost_message]", system_error, alert=TRUE)
 		. = TRUE
 	if(emagged)
 	   // shuttle timers use 1/10th seconds internally

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -128,14 +128,14 @@
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		minor_announce("The emergency shuttle will launch in \
 			[TIME_LEFT] seconds.", alert=TRUE)
-	if(emagged)
-		// shuttle timers use 1/10th seconds internally
-		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
-		var/system_error = emagged ? "SYSTEM ERROR:" : null
-		var/emag_boost_message = pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")
-		minor_announce("The emergency shuttle will launch in \
 			[TIME_LEFT] seconds.\n[emag_boost_message]", system_error, alert=TRUE)
 		. = TRUE
+	if(emagged)
+	   // shuttle timers use 1/10th seconds internally
+	  SSshuttle.emergency.setTimer(ENGINES_START_TIME)
+	  minor_announce("The emergency shuttle will launch in [TIME_LEFT] seconds.\
+	    \n[pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")]", "SYSTEM ERROR:", alert=TRUE)
+	  . = TRUE
 
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
 	// How did you even get on the shuttle before it go to the station?

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -131,10 +131,10 @@
 		. = TRUE
 	if(emagged)
 	   // shuttle timers use 1/10th seconds internally
-	  SSshuttle.emergency.setTimer(ENGINES_START_TIME)
-	  minor_announce("The emergency shuttle will launch in [TIME_LEFT] seconds.\
+		 SSshuttle.emergency.setTimer(ENGINES_START_TIME)
+		 minor_announce("The emergency shuttle will launch in [TIME_LEFT] seconds.\
 	    \n[pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")]", "SYSTEM ERROR:", alert=TRUE)
-	  . = TRUE
+			. = TRUE
 
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
 	// How did you even get on the shuttle before it go to the station?

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -123,9 +123,12 @@
 
 	if(ENGINES_STARTED || (!IS_DOCKED))
 		return .
-
 	// Check to see if we've reached criteria for early launch
-	if((authorized.len >= auth_need) || emagged)
+	if(authorized.len >= auth_need)
+		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
+		minor_announce("The emergency shuttle will launch in \
+			[TIME_LEFT] seconds.", alert=TRUE)
+	if(emagged)
 		// shuttle timers use 1/10th seconds internally
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		var/system_error = emagged ? "SYSTEM ERROR:" : null

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -128,13 +128,11 @@
 		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
 		minor_announce("The emergency shuttle will launch in \
 			[TIME_LEFT] seconds.", alert=TRUE)
-		. = TRUE
 	if(emagged)
-	   // shuttle timers use 1/10th seconds internally
-		 SSshuttle.emergency.setTimer(ENGINES_START_TIME)
-		 minor_announce("The emergency shuttle will launch in [TIME_LEFT] seconds.\
-	    \n[pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")]", "SYSTEM ERROR:", alert=TRUE)
-			. = TRUE
+	  // shuttle timers use 1/10th seconds internally
+		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
+		minor_announce("The emergency shuttle will launch in [TIME_LEFT] seconds.\
+		\n[pick("STRAP IN FOR EMERGENCY BURN", "PREPARE FOR LUDICROUS SPEED", "MAKING THE JUMP TO %@ERROR^& IN UNDER 12 PARSECS", "INERTIAL DAMPENERS OFFLINE")]", "SYSTEM ERROR:", alert=TRUE)
 
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
 	// How did you even get on the shuttle before it go to the station?


### PR DESCRIPTION
:cl: Bksparkie1
fix: Fixed emergency shuttle launching quickly as if emagged, when it really was not
/:cl:

[why]: # Cause it is a bug that needed fixing.
fixes #706
