### PR TITLE
Emitter projectile Fix

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -60,7 +60,7 @@
 
 /obj/item/shield/energy
 	name = "energy combat shield"
-	desc = "A shield capable of stopping most melee attacks. Protects user from almost all energy projectiles. It can be retracted, expanded, and stored anywhere."
+	desc = "A shield that reflects almost all energy projectiles, but is useless against physical attacks. It can be retracted, expanded, and stored anywhere."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "eshield0" // eshield1 for expanded
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -66,7 +66,10 @@
 					P.firer = src
 					P.yo = new_y - curloc.y
 					P.xo = new_x - curloc.x
-					P.Angle = null
+					var/new_angle_s = P.Angle + rand(120,240)
+					while(new_angle_s > 180)	// Translate to regular projectile degrees
+						new_angle_s -= 360
+					P.setAngle(new_angle_s)
 
 				return -1 // complete projectile permutation
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -146,6 +146,10 @@
 				P.firer = src
 				P.yo = new_y - curloc.y
 				P.xo = new_x - curloc.x
+				var/new_angle_s = P.Angle + rand(120,240)
+				while(new_angle_s > 180)	// Translate to regular projectile degrees
+					new_angle_s -= 360
+				P.setAngle(new_angle_s)
 
 			return -1 // complete projectile permutation
 


### PR DESCRIPTION
This should fix the projectile sprite flying sideways.
ports tgstation/tgstation#34065
🆑 Robustin, ported by scrubmcnoob
fix: Projectile reflections are fixed and will now properly reflect back in the general direction of the projectile's origination point.
fix: Energy shield description updated to remove misleading information and reflect (heh) its true properties.
/🆑
