### PR TITLE
Changed changeling_scaling_coefficient from 6 to 8 to combat ridiculous changeling numbers on high pop

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -210,7 +210,7 @@ SHUTTLE_REFUEL_DELAY 12000
 ## Used as (Antagonists = Population / Coeff)
 ## Set to 0 to disable scaling and use default numbers instead.
 TRAITOR_SCALING_COEFF 6
-CHANGELING_SCALING_COEFF 12
+CHANGELING_SCALING_COEFF 8
 
 ## Variables calculate how number of open security officer positions will scale to population.
 ## Used as (Officers = Population / Coeff)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -210,7 +210,7 @@ SHUTTLE_REFUEL_DELAY 12000
 ## Used as (Antagonists = Population / Coeff)
 ## Set to 0 to disable scaling and use default numbers instead.
 TRAITOR_SCALING_COEFF 6
-CHANGELING_SCALING_COEFF 6
+CHANGELING_SCALING_COEFF 12
 
 ## Variables calculate how number of open security officer positions will scale to population.
 ## Used as (Officers = Population / Coeff)


### PR DESCRIPTION
:cl: Armrha
experiment: Adjusting changeling scaling coefficient from 6 to 12 (Changelings = Pop / Scaling Coefficient).
/:cl:

[why]: We've had a huge increase in player population lately, and there has been a strong trend toward Changeling rounds becoming extremely non-challenging for the Changelings. When Changelings outnumber any single department, they can roll up to any group and just take it over by force. They don't even have to bother with stealth. Armblades out they can roll sec and sec can't keep them all down long enough to dust even one generally when you have 9 changelings. This change doubles the scaling coefficient for then Changeling mode and would be worth testing to see if it makes those rounds more fun. Changelings should always have to be stealthy.
