### PR TITLE
Giving new verbs for admins to clean atmos messes up.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -77,6 +77,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/cmd_admin_freeze,
 	/client/proc/respawn_character,
+	/client/proc/reset_atmos,
+	/client/proc/fill_breach,
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,
 	/datum/admins/proc/end_round,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1221,7 +1221,6 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 				A.gases["o2"][MOLES] = MOLES_O2STANDARD
 				A.gases["n2"][MOLES] = MOLES_N2STANDARD
 				A.gases["co2"][MOLES] = 0
-				A.gases["freon"][MOLES] = 0
 				A.gases["plasma"][MOLES] = 0
 				A.temperature = T20C
 	message_admins("[key_name(src)] cleaned air within [size] tiles.")
@@ -1249,7 +1248,6 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 				A.gases["o2"][MOLES] = MOLES_O2STANDARD
 				A.gases["n2"][MOLES] = MOLES_N2STANDARD
 				A.gases["co2"][MOLES] = 0
-				A.gases["freon"][MOLES] = 0
 				A.gases["plasma"][MOLES] = 0
 				A.temperature = T20C
 	message_admins("[key_name(src)] filled the hull breaches in [size] tiles.")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1208,6 +1208,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	set category = "Special Verbs"
 	set desc = "Cleans the air in a radius of harmful gasses like plasma and n2o "
 	var/size = input("How big?", "Input") in list(5, 10, 20, "Cancel")
+	if(!check_rights(R_ADMIN))
+		return
 	if(size == "Cancel")
 		return 0
 	for(var/turf/open/floor/T in range(size))
@@ -1230,6 +1232,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	set category = "Special Verbs"
 	set desc = "Spawns plating over space breachs"
 	var/size = input("How big?", "Input") in list(5, 10, "Cancel")
+	if(!check_rights(R_ADMIN))
+		return
 	if(size == "Cancel")
 		return 0
 	for(var/turf/open/space/T in range(size))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1206,7 +1206,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 /client/proc/reset_atmos()
 	set name = "Clean Air"
 	set category = "Special Verbs"
-	set desc = "Cleans the air in a radius of harmful gasses like plasma and n2o "
+	set desc = "Cleans the air in a radius of harmful gasses like plasma and n2o"
 	var/size = input("How big?", "Input") in list(5, 10, 20, "Cancel")
 	if(!check_rights(R_ADMIN))
 		return
@@ -1221,6 +1221,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 				A.gases["o2"][MOLES] = MOLES_O2STANDARD
 				A.gases["n2"][MOLES] = MOLES_N2STANDARD
 				A.gases["co2"][MOLES] = 0
+				A.gases["freon"][MOLES] = 0
 				A.gases["plasma"][MOLES] = 0
 				A.temperature = T20C
 	message_admins("[key_name(src)] cleaned air within [size] tiles.")
@@ -1228,9 +1229,9 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 
 
 /client/proc/fill_breach()
-	set name = "Fill Hull Breach"
+	set name = "Fill Hull Breaches"
 	set category = "Special Verbs"
-	set desc = "Spawns plating over space breachs"
+	set desc = "Spawns plating over space breaches"
 	var/size = input("How big?", "Input") in list(5, 10, "Cancel")
 	if(!check_rights(R_ADMIN))
 		return
@@ -1248,10 +1249,11 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 				A.gases["o2"][MOLES] = MOLES_O2STANDARD
 				A.gases["n2"][MOLES] = MOLES_N2STANDARD
 				A.gases["co2"][MOLES] = 0
+				A.gases["freon"][MOLES] = 0
 				A.gases["plasma"][MOLES] = 0
 				A.temperature = T20C
-	message_admins("[key_name(src)] filled the hullbreachs in [size] tiles.")
-	log_game("[key_name(src)] filled the hullbreachs in [size] tiles.")
+	message_admins("[key_name(src)] filled the hull breaches in [size] tiles.")
+	log_game("[key_name(src)] filled the hull breaches in [size] tiles.")
 
 
 /client/proc/smite(mob/living/carbon/human/target as mob)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1202,6 +1202,54 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 
 	SSblackbox.add_details("admin_toggle","Toggled Hub Visibility|[GLOB.hub_visibility]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+
+/client/proc/reset_atmos()
+	set name = "Clean Air"
+	set category = "Special Verbs"
+	set desc = "Cleans the air in a radius of harmful gasses like plasma and n2o "
+	var/size = input("How big?", "Input") in list(5, 10, 20, "Cancel")
+	if(size == "Cancel")
+		return 0
+	for(var/turf/open/floor/T in range(size))
+		if(T.air)
+			var/datum/gas_mixture/A = T.air
+			T.overlays.Cut()
+			if(A)
+				A.assert_gases(arglist(GLOB.hardcoded_gases))
+				A.gases["o2"][MOLES] = MOLES_O2STANDARD
+				A.gases["n2"][MOLES] = MOLES_N2STANDARD
+				A.gases["co2"][MOLES] = 0
+				A.gases["plasma"][MOLES] = 0
+				A.temperature = T20C
+	message_admins("[key_name(src)] cleaned air within [size] tiles.")
+	log_game("[key_name(src)] cleaned air within [size] tiles.")
+
+
+/client/proc/fill_breach()
+	set name = "Fill Hull Breach"
+	set category = "Special Verbs"
+	set desc = "Spawns plating over space breachs"
+	var/size = input("How big?", "Input") in list(5, 10, "Cancel")
+	if(size == "Cancel")
+		return 0
+	for(var/turf/open/space/T in range(size))
+		T.ChangeTurf(/turf/open/floor/plating)
+	spawn(1)
+	for(var/turf/open/floor/T in range(size))
+		if(T.air)
+			var/datum/gas_mixture/A = T.air
+			T.overlays.Cut()
+			if(A)
+				A.assert_gases(arglist(GLOB.hardcoded_gases))
+				A.gases["o2"][MOLES] = MOLES_O2STANDARD
+				A.gases["n2"][MOLES] = MOLES_N2STANDARD
+				A.gases["co2"][MOLES] = 0
+				A.gases["plasma"][MOLES] = 0
+				A.temperature = T20C
+	message_admins("[key_name(src)] filled the hullbreachs in [size] tiles.")
+	log_game("[key_name(src)] filled the hullbreachs in [size] tiles.")
+
+
 /client/proc/smite(mob/living/carbon/human/target as mob)
 	set name = "Smite"
 	set category = "Fun"


### PR DESCRIPTION
:cl: 
add: Adds 2 news verbs to the admin arsenal.
/:cl:

[why]: # Those allow the admin to quickly clean the air in case of any plasma, Co2, or N20 leak, and fix bomb explosions quickly. 
![1](https://user-images.githubusercontent.com/7472150/38290933-7cf6372e-37ab-11e8-8acf-c11d39263334.png)
![2](https://user-images.githubusercontent.com/7472150/38290934-7dd1bf6a-37ab-11e8-99a1-7aa584ad31c1.png)
![3](https://user-images.githubusercontent.com/7472150/38290936-7e932eca-37ab-11e8-9937-f45e7f0629ba.png)


