### PR TITLE
Lint and Correct README.md for Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
-## OracleStation codebase
+# OracleStation
+
+[![Build Status](https://travis-ci.org/OracleStation/OracleStation.svg?branch=master)](https://travis-ci.org/OracleStation/OracleStation)
 
 ## DOWNLOADING
 
-There are a number of ways to download the source code. Some are described here, an alternative all-inclusive guide is also located at http://www.tgstation13.org/wiki/Downloading_the_source_code
+There are a number of ways to download the source code. Some are described here, an alternative all-inclusive guide is also located at <http://www.tgstation13.org/wiki/Downloading_the_source_code>
 
 Option 1:
-Follow this: http://www.tgstation13.org/wiki/Setting_up_git
+Follow this: <http://www.tgstation13.org/wiki/Setting_up_git>
 
-Option 2: Download the source code as a zip by clicking the ZIP button in the
-code tab of https://github.com/tgstation/tgstation
+Option 2: Download the source code as a zip by clicking [here](https://github.com/OracleStation/OracleStation/archive/master.zip)
 (note: this will use a lot of bandwidth if you wish to update and is a lot of
 hassle if you want to make any changes at all, so it's not recommended.)
 
 ## INSTALLATION
 
 First-time installation should be fairly straightforward.  First, you'll need
-BYOND installed.  You can get it from http://www.byond.com/.  Once you've done
+BYOND installed.  You can get it from <http://www.byond.com/>.  Once you've done
 that, extract the game files to wherever you want to keep them.  This is a
 sourcecode-only release, so the next step is to compile the server files.
 Open tgstation.dme by double-clicking it, open the Build menu, and click
 compile.  This'll take a little while, and if everything's done right you'll get
 a message like this:
 
-```
+```dm
 saving tgstation.dmb (DEBUG mode)
 tgstation.dmb - 0 errors, 0 warnings
 ```
 
 If you see any errors or warnings, something has gone wrong - possibly a corrupt
 download or the files extracted wrong. If problems persist, ask for assistance
-in irc://irc.rizon.net/coderbus
+on [Discord](https://discord.gg/JbNpMuP)
 
 Once that's done, open up the config folder.  You'll want to edit config.txt to
 set the probabilities for different gamemodes in Secret and to set your server
@@ -39,21 +40,21 @@ except Extended, as they have various issues and aren't currently being tested,
 so they may have unknown and bizarre bugs.  Extended is essentially no mode, and
 isn't in the Secret rotation by default as it's just not very fun.
 
-You'll also want to edit config/admins.txt to remove the default admins and add
+You'll also want to edit `config/admins.txt` to remove the default admins and add
 your own.  "Game Master" is the highest level of access, and probably the one
 you'll want to use for now.  You can set up your own ranks and find out more in
 config/admin_ranks.txt
 
 The format is
 
-```
+```text
 byondkey = Rank
 ```
 
 where the admin rank must be properly capitalised.
 
 Finally, to start the server, run Dream Daemon and enter the path to your
-compiled tgstation.dmb file.  Make sure to set the port to the one you
+compiled `tgstation.dmb` file.  Make sure to set the port to the one you
 specified in the config.txt, and set the Security box to 'Safe'.  Then press GO
 and the server should start up and be ready to join. It is also recommended that
 you set up the SQL backend (see below).
@@ -64,32 +65,33 @@ To update an existing installation, first back up your /config and /data folders
 as these store your server configuration, player preferences and banlist.
 
 Then, extract the new files (preferably into a clean directory, but updating in
-place should work fine), copy your /config and /data folders back into the new
+place should work fine), copy your `/config` and `/data` folders back into the new
 install, overwriting when prompted except if we've specified otherwise, and
 recompile the game.  Once you start the server up again, you should be running
 the new version.
+
+<!-- Don't believe the server tools apply to us, keeping commented out for review
 
 ## HOSTING
 
 If you'd like a more robust server hosting option for tgstation and its
 derivatives. Check out our server tools suite at
 https://github.com/tgstation/tgstation-server
+-->
 
 ## MAPS
 
-/tg/station currently comes equipped with six maps.
+Oraclestation currently comes equipped with six maps.
 
 * [BoxStation (default)](http://tgstation13.org/wiki/Boxstation)
 * [MetaStation](https://tgstation13.org/wiki/MetaStation)
 * [DeltaStation](https://tgstation13.org/wiki/DeltaStation)
 * [OmegaStation](https://tgstation13.org/wiki/OmegaStation)
 * [PubbyStation](https://tgstation13.org/wiki/PubbyStation)
-* [CereStation](https://tgstation13.org/wiki/CereStation)
 
+All maps have their own code file that is in the base of the `_maps` directory. Maps are loaded dynamically when the game starts. Follow this guideline when adding your own map, to your fork, for easy compatibility.
 
-All maps have their own code file that is in the base of the _maps directory. Maps are loaded dynamically when the game starts. Follow this guideline when adding your own map, to your fork, for easy compatibility.
-
-The map that will be loaded for the upcoming round is determined by reading data/next_map.json, which is a copy of the json files found in the _maps tree. If this file does not exist, the default map from config/maps.txt will be loaded. Failing that, tgstation2 will be loaded. If you want to set a specific map to load next round you can use the Change Map verb in game before restarting the server or copy a json from _maps to data/next_map.json before starting the server. Also, for debugging purposes, ticking a corresponding map's code file in Dream Maker will force that map to load every round.
+The map that will be loaded for the upcoming round is determined by reading data/next_map.json, which is a copy of the json files found in the `_maps` tree. If this file does not exist, the default map from `config/maps.txt` will be loaded. Failing that, tgstation2 will be loaded. If you want to set a specific map to load next round you can use the Change Map verb in game before restarting the server or copy a json from `_maps` to `data/next_map.json` before starting the server. Also, for debugging purposes, ticking a corresponding map's code file in Dream Maker will force that map to load every round.
 
 If you are hosting a server, and want randomly picked maps to be played each round, you can enable map rotation in [config.txt](config/config.txt) and then set the maps to be picked in the [maps.txt](config/maps.txt) file.
 
@@ -97,20 +99,19 @@ Anytime you want to make changes to a map it's imperative you use the [Map Mergi
 
 ## AWAY MISSIONS
 
-/tg/station supports loading away missions however they are disabled by default.
+Oraclestation supports loading away missions however they are disabled by default.
 
-Map files for away missions are located in the _maps/RandomZLevels directory. Each away mission includes it's own code definitions located in /code/modules/awaymissions/mission_code. These files must be included and compiled with the server beforehand otherwise the server will crash upon trying to load away missions that lack their code.
+Map files for away missions are located in the `_maps/RandomZLevels` directory. Each away mission includes it's own code definitions located in `/code/modules/awaymissions/mission_code`. These files must be included and compiled with the server beforehand otherwise the server will crash upon trying to load away missions that lack their code.
 
 To enable an away mission open `config/awaymissionconfig.txt` and uncomment one of the .dmm lines by removing the #. If more than one away mission is uncommented then the away mission loader will randomly select one the enabled ones to load.
 
 ## SQL SETUP
 
-The SQL backend requires a MySQL server. SQL is required for the library, stats tracking, admin notes, and job-only bans, among other features, mostly related to server administration. Your server details go in /config/dbconfig.txt, and the SQL schema is in /SQL/tgstation_schema.sql and /SQL/tgstation_schema_prefix.sql depending on if you want table prefixes.  More detailed setup instructions are located here: http://www.tgstation13.org/wiki/Downloading_the_source_code#Setting_up_the_database
+The SQL backend requires a MySQL server. SQL is required for the library, stats tracking, admin notes, and job-only bans, among other features, mostly related to server administration. Your server details go in `/config/dbconfig.txt`, and the SQL schema is in `/SQL/tgstation_schema.sql` and `/SQL/tgstation_schema_prefix.sql` depending on if you want table prefixes.  More detailed setup instructions are located here: <http://www.tgstation13.org/wiki/Downloading_the_source_code#Setting_up_the_database>
 
 ## IRC BOT SETUP
 
-Included in the repository is a python3 compatible IRC bot capable of relaying adminhelps to a specified
-IRC channel/server, see the /tools/minibot folder for more
+Included in the repository is a python3 compatible IRC bot capable of relaying adminhelps to a specified IRC channel/server, see the `/tools/minibot` folder for more
 
 ## CONTRIBUTING
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ https://github.com/tgstation/tgstation-server
 
 ## MAPS
 
-Oraclestation currently comes equipped with six maps.
+Oraclestation currently comes equipped with five maps.
 
 * [BoxStation (default)](http://tgstation13.org/wiki/Boxstation)
 * [MetaStation](https://tgstation13.org/wiki/MetaStation)

--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 
 ## LICENSE
 
-All code after [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/tgstation/tgstation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU AGPL v3](http://www.gnu.org/licenses/agpl-3.0.html).
+All code after [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/OracleStation/OracleStation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU AGPL v3](http://www.gnu.org/licenses/agpl-3.0.html).
 
-All code before [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/tgstation/tgstation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.html).
+All code before [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/OracleStation/OracleStation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.html).
 (Including tools unless their readme specifies otherwise.)
 
-See LICENSE-AGPLv3.txt and LICENSE-GPLv3.txt for more details.
+See [`LICENSE-AGPLv3.txt`](LICENSE-AGPLv3.txt) and [`LICENSE-GPLv3.txt`](LICENSE-GPLv3.txt) for more details.
 
 tgui clientside is licensed as a subproject under the MIT license.
 Font Awesome font files, used by tgui, are licensed under the SIL Open Font License v1.1
 tgui assets are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
 
-See tgui/LICENSE.md for the MIT license.
-See tgui/assets/fonts/SIL-OFL-1.1-LICENSE.md for the SIL Open Font License.
+See `tgui/LICENSE.md` for the MIT license.
+See `tgui/assets/fonts/SIL-OFL-1.1-LICENSE.md` for the SIL Open Font License.
 
 All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](http://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
 


### PR DESCRIPTION
Linted with [DavidAnson/vscode-markdownlint
](https://github.com/DavidAnson/vscode-markdownlint)

Keeping wiki links to tg's for now, as they have more up to date docs

Not sure what to do about the SQL and hosting sections and references. Up for review