### PR TITLE
Fixes Revenants killing admins

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -7,7 +7,7 @@
 #define REVENANT_NAME_FILE "revenant_names.json"
 
 /mob/living/simple_animal/revenant
-	name = "\a Revenant"
+	name = "revenant"
 	desc = "A malevolent spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "revenant_idle"


### PR DESCRIPTION
Ports: https://github.com/tgstation/tgstation/pull/36958

For whatever reason, the \a macro here translates into %ff%06 in url_encode() which makes browserOutput.js throw a "The URI to be decoded is not a valid encoding" error. it was superfluous anyways. While revenants are alive, they use their fluffy name like "spirit of abysmal hellfire" which is why this bug only triggered in death.

🆑 Naksu
fix: Fixed (dead) revenants being unable to deadchat or ahelp
/🆑
