### PR TITLE
Allows office chairs to rotate

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -396,8 +396,13 @@
 
 // Simple helper to face what you clicked on, in case it should be needed in more than one place
 /mob/proc/face_atom(atom/A)
-	if( buckled || stat != CONSCIOUS || !A || !x || !y || !A.x || !A.y )
+	if( stat != CONSCIOUS || !A || !x || !y || !A.x || !A.y )
 		return
+
+	if(buckled) //allows rolling chairs to rotate with you, a nice touch
+		if(!buckled.can_buckled_rotate)
+			return
+
 	var/dx = A.x - x
 	var/dy = A.y - y
 	if(!dx && !dy) // Wall items are graphically shifted but on the floor
@@ -421,6 +426,9 @@
 			setDir(EAST)
 		else
 			setDir(WEST)
+
+	if(buckled && buckled.can_buckled_rotate) //face whatever we are buckled to if it can rotate too
+		buckled.setDir(dir)
 
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen_gen.dmi'

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -7,6 +7,7 @@
 	var/list/mob/living/buckled_mobs = null //list()
 	var/max_buckled_mobs = 1
 	var/buckle_prevents_pull = FALSE
+	var/can_buckled_rotate = 0 //can people rotate when buckled to this object? eg: rolling chairs
 
 //Interaction
 /atom/movable/attack_hand(mob/living/user)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -193,6 +193,7 @@
 	anchored = FALSE
 	buildstackamount = 5
 	item_chair = null
+	can_buckled_rotate = 1
 
 /obj/structure/chair/office/light
 	icon_state = "officechair_white"


### PR DESCRIPTION
Adds can_buckled_rotate var to /atom/movable and edits FaceAtom proc so that if you are buckled to something you will turn with the buckled object if can_buckled_rotate is 1. Only office chairs utilize this for now.

:cl: Vivalas
add: Office chairs now rotate when you interact with other objects for maximum immersion
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 

It's a nice fluff features from HRP servers.
