### PR TITLE
Admin Announce Tweak

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -474,7 +474,7 @@
 	if(message)
 		if(!check_rights(R_SERVER,0))
 			message = adminscrub(message,500)
-		to_chat(world, "<font size='15' color='blue'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><font size='4' color='black'> </span>\n \t [message]")
+		to_chat(world, "<span class='adminannouncement'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</span><span class='adminnotice'>\n \t [message]</b></span>")
 		log_admin("Announce: [key_name(usr)] : [message]")
 	SSblackbox.add_details("admin_verb","Announce") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -474,7 +474,7 @@
 	if(message)
 		if(!check_rights(R_SERVER,0))
 			message = adminscrub(message,500)
-		to_chat(world, "<span class='adminnotice'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b></span>\n \t [message]")
+		to_chat(world, "<font size='15' color='blue'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><font size='4' color='black'> </span>\n \t [message]")
 		log_admin("Announce: [key_name(usr)] : [message]")
 	SSblackbox.add_details("admin_verb","Announce") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -304,6 +304,7 @@ h1.alert, h2.alert		{color: #000000;}
 .notice					{color: #000099;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
+.adminannouncement		{color: #0000ff; font-weight: bold; font-size: 64px;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
 .mentor				{color: #8A2BE2;}
 .mentoradmin				{color: #8A2BE2;	font-weight: bold;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -76,6 +76,7 @@ h1.alert, h2.alert		{color: #000000;}
 .notice					{color: #000099;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
+.adminannouncement			{color: #0000ff; font-weight: bold; font-size: 8;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
 .mentor				{color: #8A2BE2;}
 .mentoradmin				{color: #8A2BE2;	font-weight: bold;}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8481356/38602111-d03e79e6-3d37-11e8-9e66-04271fb41b90.png)
The admin announcement is no longer normal size text so it isn't missed.

Fixes #838 