### PR TITLE
Fixes the solar duplication

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -76,7 +76,7 @@
 	id = "foreport";
 	name = "Fore-Port Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/port/fore)
 "aam" = (
 /obj/structure/cable,
@@ -175,7 +175,7 @@
 	id = "foreport";
 	name = "Fore-Port Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/port/fore)
 "aav" = (
 /obj/effect/landmark/marauder_entry,
@@ -560,7 +560,7 @@
 	id = "forestarboard";
 	name = "Fore-Starboard Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/starboard/fore)
 "abw" = (
 /obj/structure/cable,
@@ -901,7 +901,7 @@
 	id = "forestarboard";
 	name = "Fore-Starboard Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/starboard/fore)
 "acm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -64983,7 +64983,7 @@
 	id = "aftport";
 	name = "Aft-Port Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/port/aft)
 "cuf" = (
 /obj/structure/closet,
@@ -66057,7 +66057,7 @@
 	id = "aftport";
 	name = "Aft-Port Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/port/aft)
 "cwf" = (
 /obj/structure/cable/yellow{
@@ -82456,7 +82456,7 @@
 	id = "aftstarboard";
 	name = "Aft-Starboard Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/starboard/aft)
 "dbK" = (
 /obj/structure/lattice/catwalk,
@@ -82481,7 +82481,7 @@
 	id = "aftstarboard";
 	name = "Aft-Starboard Solar Array"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/turf/open/floor/plating/airless,
 /area/solar/starboard/aft)
 "dbM" = (
 /obj/structure/lattice/catwalk,


### PR DESCRIPTION
:cl: Purpose
fix: Fixes the duplication of the solars appearance.
/:cl:

With the new solar sprites we had, the floor sprites were superfluous and incorrect. This updates this, and fixes the lighting problem too.

Before: 
![image](https://user-images.githubusercontent.com/7415122/39046455-2e8467c4-448e-11e8-8b49-1234454eaada.png)

After: 
![image](https://user-images.githubusercontent.com/7415122/39046464-349ace14-448e-11e8-9b3d-f65f1784a54b.png)
