### PR TITLE
LOOC tweak

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -158,7 +158,11 @@
 			else
 				to_chat(C, "<span class='looc'><font color='black'>(R)</font>LOOC: [ADMIN_LOOKUPFLW(mob)]: [msg]</span>")
 		else if(C in clients_to_hear)
-			to_chat(C, "<span class='looc'>LOOC: [mob.name]: [msg]</span>")
+			if(isobserver(mob) && !(prefs.chat_toggles & CHAT_ANONDCHAT))
+				to_chat(C, "<span class='looc'>LOOC: [mob.key]: [msg]</span>")//so ghosts and other garbage print their ckey
+			else
+				to_chat(C, "<span class='looc'>LOOC: Ghost of [mob.name]: [msg]</span>")
+
 
 /mob/proc/get_looc_source()
 	return src


### PR DESCRIPTION
Ghosts will now print their ckey instead of their mob name, unless they have dchat anonimity turned on, in which case they will still print their mob name.

:cl: Flatty
tweak: Non-anonymous ghosts will now print their CKEY when talking in LOOC.
/:cl: