### PR TITLE
hotfix for chem recipes requiring fungus until a way to get fungus is added

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -45,4 +45,4 @@
 	name = "Lysergic acid diethylamide"
 	id = "lsd"
 	results = list("lsd" = 2)
-	required_reagents = list("fungus" = 1, "diethylamine" = 1)
+	required_reagents = list("mushroomhallucinogen" = 1, "diethylamine" = 1)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -22,7 +22,7 @@
 	name = "Spaceacillin"
 	id = "spaceacillin"
 	results = list("spaceacillin" = 2)
-	required_reagents = list("fungus" = 1, "ethanol" = 1)
+	required_reagents = list("mushroomhallucinogen" = 1, "ethanol" = 1)
 
 /datum/chemical_reaction/synaptizine
 	name = "Synaptizine"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -583,7 +583,7 @@
 	name = "carpet"
 	id = "carpet"
 	results = list("carpet" = 2)
-	required_reagents = list("fungus" = 1, "blood" = 1)
+	required_reagents = list("mushroomhallucinogen" = 1, "blood" = 1)
 
 /datum/chemical_reaction/oil
 	name = "Oil"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -24,7 +24,7 @@
 	name = "Itching Powder"
 	id = "itching_powder"
 	results = list("itching_powder" = 3)
-	required_reagents = list("welding_fuel" = 1, "ammonia" = 1, "fungus" = 1)
+	required_reagents = list("welding_fuel" = 1, "ammonia" = 1, "mushroomhallucinogen" = 1)
 
 /datum/chemical_reaction/facid
 	name = "Fluorosulfuric acid"


### PR DESCRIPTION
:cl:imsxz
fix: chem recipes requiring fungus have been replaced with mushroomhallucinogen until a way to get fungus has been added
/:cl: 
chems that can be very necessary during certain situations like spaceacillin cant be made currently because theres no way to get fungus, spaceacillin is needed to cure fungal TB. theres other important med chems too like LSD that needs fungus. this PR replaces fungus in recipes to mushroomhallucinogen until a way to get fungus is added.

also webeditor is great and anyone who says otherwise has a wrong opinion