### PR TITLE
Synthanol can now be created

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -726,7 +726,7 @@
 /datum/chemical_reaction/synthanol
 	name = "Synthanol"
 	id = "synthanol"
-	required_reagents = list("lube" = 1, "plasma" = 1, "fuel" = 1)
+	required_reagents = list("lube" = 1, "plasma" = 1, "welding_fuel" = 1)
 	results = list("synthanol" = 3)
 
 /datum/chemical_reaction/synthanol/robottears


### PR DESCRIPTION
Fixes an oversight in code relating to welding fuel's ID.

Fixes #890

:cl:
fix: Synthanol can now be produced.
/:cl: