### PR TITLE
fixes dumb virology bug

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -183,8 +183,8 @@
 		properties["stealth"] += S.stealth
 		properties["stage_rate"] += S.stage_speed
 		properties["transmittable"] += S.transmittable
-		properties["severity"] = max(properties["severity"], S.severity) // severity is based on the highest severity symptom
-	return
+		if(!S.neutered)
+			properties["severity"] = max(properties["severity"], S.severity) // severity is based on the highest severity non-neutered symptom
 
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/AssignProperties()


### PR DESCRIPTION
:cl:imsxz
fix: neutered symptoms no longer change the viruses severity.
/:cl:
dumb bug, makes medibots try to cure people of beneficial diseases because it sees it has harmful even if all the harmful symptoms are neutered. Bug also let you make fake lethal diseases with the biohazard warning and everything which is kinda silly.