### PR TITLE
ports You can no longer buckle anchored mobs to things. + Anchors the ashwalker tendril

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -100,7 +100,7 @@
 
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!in_range(user, src) || user.stat || user.restrained())
+	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated() || M.anchored)
 		return FALSE
 
 	add_fingerprint(user)

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -11,7 +11,7 @@
 	maxHealth = 200
 	loot = list(/obj/effect/collapse)
 	var/meat_counter = 6
-	anchored = TRUE
+	anchored = TRUE //stops it being moved
 
 /mob/living/simple_animal/hostile/spawner/lavaland/ash_walker/death()
 	new /obj/item/device/assembly/signaler/anomaly (get_step(loc, pick(GLOB.alldirs)))

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -11,6 +11,7 @@
 	maxHealth = 200
 	loot = list(/obj/effect/collapse)
 	var/meat_counter = 6
+	anchored = TRUE
 
 /mob/living/simple_animal/hostile/spawner/lavaland/ash_walker/death()
 	new /obj/item/device/assembly/signaler/anomaly (get_step(loc, pick(GLOB.alldirs)))


### PR DESCRIPTION
Anchored mobs can no longer be buckled to chairs. Ports https://github.com/tgstation/tgstation/pull/37312

fixes #859

:cl: Dax Dupont ported by Cactus2388
fix: Fixes an exploit where tendrils/other spawners/anchored mobs in general could be buckled to things and thus moved around.
/:cl:


