### PR TITLE
Fixes ghost UI

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -150,12 +150,12 @@
 
 //Ghosts
 
-#define ui_ghost_jumptomob "SOUTH:6,CENTER-2.5:24"
-#define ui_ghost_orbit "SOUTH:6,CENTER-1.5:24"
-#define ui_ghost_reenter_corpse "SOUTH:6,CENTER-0.5:24"
-#define ui_ghost_teleport "SOUTH:6,CENTER+0.5:24"
-#define ui_ghost_pai "SOUTH: 6, CENTER+1.5:24"
-#define ui_ghost_spawner_menu "SOUTH:6, CENTER+2.5:24"
+#define ui_ghost_jumptomob "SOUTH:6,CENTER-3:24"
+#define ui_ghost_orbit "SOUTH:6,CENTER-2:24"
+#define ui_ghost_reenter_corpse "SOUTH:6,CENTER-1:24"
+#define ui_ghost_teleport "SOUTH:6,CENTER:24"
+#define ui_ghost_pai "SOUTH: 6,CENTER+1:24"
+#define ui_ghost_spawner_menu "SOUTH:6,CENTER+2:24"
 
 //Hand of God, god
 


### PR DESCRIPTION
:cl: Flatty
fix: Ghost UI now works for people playing on BYOND 511 (the old one)
/:cl:

Turns out decimal `screen_loc` offsets are a new feature of BYOND 512, which lead to everyone on 511 not seeing the darn thing.

I don't encourage anyone to udpdate to 512 unless they know what they're doing.