### PR TITLE
New Necropolis Tendril Loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -11,7 +11,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,29)
 	switch(loot)
 		if(1)
 			new /obj/item/device/shared_storage/red(src)
@@ -71,6 +71,13 @@
 			new /obj/item/bedsheet/cult(src)
 		if(28)
 			new /obj/item/disk/design_disk/modkit_disc/bounty(src)
+		if(29)
+			new /obj/item/bedsheet/cosmos(src)
+			new /obj/item/ore/bluespace_crystal(src)
+			new /obj/item/ore/bluespace_crystal(src)
+			new /obj/item/ore/bluespace_crystal(src)
+			new /obj/item/ore/bluespace_crystal(src)
+			
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION
Why? To add a small bit of variation to the necropolis crates, and to implement an unused sprite. The bed sheet fits on the neck slot.

![blanketloot](https://user-images.githubusercontent.com/27895840/40212763-57a08acc-5a17-11e8-941c-3a90c7c15ab3.PNG)


:cl: optional name here
add: New Necropolis Tendril Loot
/:cl:

