### PR TITLE
Removes the build your own shuttle kit

### DIFF
--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -13,7 +13,7 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_airless.dmm
+_maps/shuttles/emergency_airless.dmm
 _maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
 #_maps/shuttles/emergency_clown.dmm


### PR DESCRIPTION
I am pretty sure EVERYONE by now is fed up with the same thing happening each round. All the BYOSK does it piss off the entire crew and generate copious amounts of salt, honestly the asteroid is better than this. Yes I know this is a salt PR but I feel it is required, since I think EVERYONE can agree the BYOSK is a pain in the ass for everyone involved, including just general crew

:cl: AffectedArc07
del: Decomissioned the Build-Your-Own-Shuttle-Kit. We apologise for any happy emotions this may cause.
/:cl:

Why: Fed up with the hell each round.