### PR TITLE
Bible Sounds Revisited

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 				H.update_damage_overlays()
 		H.visible_message("<span class='notice'>[user] heals [H] with the power of [deity_name]!</span>")
 		to_chat(H, "<span class='boldnotice'>May the power of [deity_name] compel you to be healed!</span>")
-		playsound(src.loc, "punch", 25, 1, -1)
+		playsound(src.loc, "curse3", 25, 1, -1)
 	return 1
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
@@ -126,12 +126,12 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		if(smack)
 			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
 					"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
-			playsound(src.loc, "curse3", 25, 1, -1)
+			playsound(src.loc, "punch", 25, 1, -1)
 			add_logs(user, M, "attacked", src)
 
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")
-		playsound(src.loc, "attackblob", 25, 1, -1)
+		playsound(src.loc, "punch", 25, 1, -1)
 
 /obj/item/storage/book/bible/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -126,12 +126,12 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		if(smack)
 			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
 					"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
-			playsound(src.loc, "punch", 25, 1, -1)
+			playsound(src.loc, "curse3", 25, 1, -1)
 			add_logs(user, M, "attacked", src)
 
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")
-		playsound(src.loc, "punch", 25, 1, -1)
+		playsound(src.loc, "attackblob", 25, 1, -1)
 
 /obj/item/storage/book/bible/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)


### PR DESCRIPTION
🆑
soundadd: Heals from the bible play an appropriate sound.
/🆑

Holy Healing now plays a rarely used sound that sounds like an RPG heal, this clears up any confusion as a result of it using the punch sound, which makes some less observant players ready to murder someone. The update makes the Chaplain just slightly more holy. Curse3 is the nicest sound I could find to represent healing (Suggested by Lynxems) while Blobattack sounds wet and squelchy, which is a far nicer sound to hear when you're whacking a lifeless body with the biggest scripture that can be found on the station!

Alternatives to Blobattack would be nice if found, but then, Blobattack seems to serve it's purpose of being a wet squishy sound.

This seems very minor, but I've seen this come up a few times personally.