### PR TITLE
Crusher Changes

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -8,7 +8,7 @@
 	name = "proto-kinetic crusher"
 	desc = "An early design of the proto-kinetic accelerator, it is little more than an combination of various mining tools cobbled together, forming a high-tech club. \
 	While it is an effective mining tool, it did little to aid any but the most skilled and/or suicidal miners against local fauna."
-	force = 20 //As much as a bone spear, but this is significantly more annoying to carry around due to requiring the use of both hands at all times
+	force = 25 //As much as a bone spear, but this is significantly more annoying to carry around due to requiring the use of both hands at all times
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
 	force_unwielded = 25 //It's never not wielded so these are the same
@@ -101,13 +101,13 @@
 			var/def_check = L.getarmor(type = "bomb")
 			if((user.dir & backstab_dir) && (L.dir & backstab_dir))
 				if(!QDELETED(C))
-					C.total_damage += 80 //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
-				L.apply_damage(80, BRUTE, blocked = def_check)
+					C.total_damage += 110 //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
+				L.apply_damage(110, BRUTE, blocked = def_check)
 				playsound(user, 'sound/weapons/kenetic_accel.ogg', 100, 1) //Seriously who spelled it wrong
 			else
 				if(!QDELETED(C))
-					C.total_damage += 50
-				L.apply_damage(50, BRUTE, blocked = def_check)
+					C.total_damage += 70
+				L.apply_damage(70, BRUTE, blocked = def_check)
 
 /obj/item/twohanded/required/kinetic_crusher/proc/Recharge()
 	if(!charged)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -11,8 +11,8 @@
 	force = 20 //As much as a bone spear, but this is significantly more annoying to carry around due to requiring the use of both hands at all times
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	force_unwielded = 20 //It's never not wielded so these are the same
-	force_wielded = 20
+	force_unwielded = 25 //It's never not wielded so these are the same
+	force_wielded = 25
 	throwforce = 5
 	throw_speed = 4
 	light_range = 5
@@ -24,7 +24,7 @@
 	sharpness = IS_SHARP
 	var/list/trophies = list()
 	var/charged = TRUE
-	var/charge_time = 15
+	var/charge_time = 10
 
 /obj/item/twohanded/required/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -8,7 +8,7 @@
 	name = "proto-kinetic crusher"
 	desc = "An early design of the proto-kinetic accelerator, it is little more than an combination of various mining tools cobbled together, forming a high-tech club. \
 	While it is an effective mining tool, it did little to aid any but the most skilled and/or suicidal miners against local fauna."
-	force = 25 //As much as a bone spear, but this is significantly more annoying to carry around due to requiring the use of both hands at all times
+	force = 25
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
 	force_unwielded = 25 //It's never not wielded so these are the same

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -57,7 +57,7 @@
 /mob/living/simple_animal/hostile/asteroid/death(gibbed)
 	SSblackbox.add_details("mobs_killed_mining","[src.type]")
 	var/datum/status_effect/crusher_damage/C = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-	if(C && crusher_loot && prob((C.total_damage/maxHealth)) * 20) //on average, you'll need to kill 20 creatures before getting the item
+	if(C && crusher_loot && prob((C.total_damage/maxHealth) * 20)) //on average, you'll need to kill 5 creatures before getting the item
 		spawn_crusher_loot()
 	..(gibbed)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -57,7 +57,7 @@
 /mob/living/simple_animal/hostile/asteroid/death(gibbed)
 	SSblackbox.add_details("mobs_killed_mining","[src.type]")
 	var/datum/status_effect/crusher_damage/C = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-	if(C && crusher_loot && prob((C.total_damage/maxHealth)) * 5) //on average, you'll need to kill 20 creatures before getting the item
+	if(C && crusher_loot && prob((C.total_damage/maxHealth)) * 20) //on average, you'll need to kill 20 creatures before getting the item
 		spawn_crusher_loot()
 	..(gibbed)
 


### PR DESCRIPTION
Changed base Kinetic Crusher damage to 25, was 20.
Changed Kinetic Crusher recharge to 10, was 15
Changed Crusher Trophy drop rate to 20, was 5

The increase to the base damage and charge speed on the crusher allow it to still stay very competitive when compared to its' counterparts the Adv. Plasma Cutter, and Kinetic Accelerator that pretty much every miner will always time over the Crusher currently.

The increase to Trophy drop rates change it from the very unlikely 1 in 20 mobs being killed for a single trophy, to 1 in 5 mobs on average. I have yet personally to ever see a crusher trophy be dropped and neither has anyone else from non trivial monsters. Trivial monsters such as bubblegum remain the same with requiring 60% of damage dealt to them to have been from a kinetic crusher.


:cl: Xantholne
balance: altered the kinetic crusher to deal more damage and drop items at a higher rate. Buffs for everyone!
/:cl:


