### PR TITLE
Allows Non-Holy created Holy Water

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -125,6 +125,12 @@
 	required_reagents = list("ammonia" = 2, "nitrogen" = 1, "oxygen" = 2)
 	required_temp = 525
 
+/datum/chemical_reaction/holywater
+	name = "Holy Water"
+	id = "holywater"
+	results = list("holywater" = 3)
+	required_reagents = list("water" = 1, "mercury" = 1, "wine" = 1)
+
 ////////////////////////////////// Mutation Toxins ///////////////////////////////////
 
 /datum/chemical_reaction/stable_mutation_toxin


### PR DESCRIPTION
Currently to acquire Holy Water to make Strange Reagent for your non cloneable species "Vox" you require Holy Water. But to get it requires a Chaplain if they aren't off validhunting or sacrificing monkies to their Pray verb, or hope to God Cargo actually orders your holy materials crate.

:cl: Xantholne
add: You can now make Holy Water; required for Strange Reagent, with Mercury, Water, and Wine. Finally Vox and others will no longer stay dead forever.
/:cl:


