### PR TITLE
Clockwork Spear + (Un)Holy Fire Weapons

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -1,6 +1,6 @@
 /obj/item/nullrod
 	name = "null rod"
-	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of Nar-Sie's followers."
+	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of illicit magic."
 	icon_state = "nullrod"
 	item_state = "nullrod"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
@@ -11,6 +11,8 @@
 	throwforce = 10
 	w_class = WEIGHT_CLASS_TINY
 	var/reskinned = FALSE
+	var/clockwork_desc = "A rod of Obsidian, a material known for corroding the Justiciar's creations."
+	var/bonus_burn = 0
 
 /obj/item/nullrod/attack_self(mob/user)
 	if(user.mind && (user.mind.isholy) && !reskinned)
@@ -390,8 +392,29 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	name = "unholy pitchfork"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	desc = "Holding this makes you look absolutely devilish."
 	attack_verb = list("poked", "impaled", "pierced", "jabbed")
+	slot_flags = SLOT_BACK
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
+	force = 10
+	bonus_burn = 5
+	
+/obj/item/nullrod/pitchfork/clockwork_spear
+	icon_state = "ratvarian_spear"
+	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/clockwork_righthand.dmi'
+	name = "clockwork spear"
+	desc = "A pointy spear made of holy brass. It ticks and tocks."
+	attack_verb = list("ticked", "tocked", "singed", "speared")
+	clockwork_desc = "A disgusting and cheap replica created by the church to imitate the divine armory of the Justiciar."
+	hitsound = 'sound/magic/clockwork/ratvar_attack.ogg'
+	
+/obj/item/nullrod/attack(mob/living/target, mob/living/carbon/human/user)
+	. = ..()
+	if(!QDELETED(target) && target.stat != DEAD)
+		var/bonus_damage = bonus_burn
+		target.adjustFireLoss(bonus_damage)
+	
+	


### PR DESCRIPTION
This will reduce the pitchfork's brute damage by 8 but now the weapon deals 5 burning damage as a trade-off. I believe that the trade is worth it, but would not be averse to increasing the fire damage to 8 if it turns out that the null rod becomes too weak as a result. This seems unlikely to me. The Pitchfork will no longer fit in the bag of the Chaplain, or any thieves.  

Also adds a reskin of the Pitchfork, a Clockwork Spear, which has it's own sound effects and list of attack verbs. Clockwork cultists will see this weapon and the base null rod differently to normal crew now, having a clock-cult description of it instead of the normal crew description. I may do this for nar’sie cultists in the future.

The Clockwork Spear was asked for by a few people, who are always thirsty for Chaplain expansions, and also means that Narnar isn’t the only eldritch god getting some lovin from the Chaplain.

:cl: 
add: Added Burn Damage potential to Null Rod reskins.
add: Added Clockwork Spear, a holy weapon of Ratvarian design that burns the non-believers.
fix: The Pitchfork can now use the back slot and can no longer be put in the bag.
tweak: The Pitchfork and Clockwork spear trade off some damage for their burning ability.
/:cl:

