### PR TITLE
Starts logging round ID in created notes.

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,10 +1,21 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 3.2; The query to update the schema revision table is:
+The latest database version is 3.3; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (3, 2);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (3, 3);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (3, 2);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (3, 3);
+
+----------------------------------------------------
+
+08 June 2018, by Birdtalon
+
+Modified table 'messages' adding the column `round_id`.
+
+ALTER TABLE `messages`
+ADD COLUMN `round_id` int(11) DEFAULT NULL AFTER `edits`;
+
+Remember to add a prefix to the table name if you use them.
 
 ----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -248,6 +248,7 @@ CREATE TABLE `messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
+  `round_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`),
   KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`),

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -248,6 +248,7 @@ CREATE TABLE `SS13_messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
+  `round_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`),
   KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`),

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -45,7 +45,8 @@
 				secret = 0
 			else
 				return
-	var/datum/DBQuery/query_create_message = SSdbcore.NewQuery("INSERT INTO [format_table_name("messages")] (type, targetckey, adminckey, text, timestamp, server, secret) VALUES ('[type]', '[target_ckey]', '[admin_ckey]', '[text]', '[timestamp]', '[server]', '[secret]')")
+	var/roundid = GLOB.round_id
+	var/datum/DBQuery/query_create_message = SSdbcore.NewQuery("INSERT INTO [format_table_name("messages")] (type, targetckey, adminckey, text, timestamp, server, secret, round_id) VALUES ('[type]', '[target_ckey]', '[admin_ckey]', '[text]', '[timestamp]', '[server]', '[secret]', '[roundid]')")
 	if(!query_create_message.warn_execute())
 		return
 	if(logged)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -196,7 +196,7 @@
 			output += "<br>[text]<hr style='background:#000000; border:0; height:1px'>"
 	if(target_ckey)
 		target_ckey = sanitizeSQL(target_ckey)
-		var/datum/DBQuery/query_get_messages = SSdbcore.NewQuery("SELECT type, secret, id, adminckey, text, timestamp, server, lasteditor FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey = '[target_ckey]' ORDER BY timestamp DESC")
+		var/datum/DBQuery/query_get_messages = SSdbcore.NewQuery("SELECT type, secret, id, adminckey, text, timestamp, server, lasteditor, round_id FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey = '[target_ckey]' ORDER BY timestamp DESC")
 		if(!query_get_messages.warn_execute())
 			return
 		var/messagedata
@@ -215,8 +215,9 @@
 			var/timestamp = query_get_messages.item[6]
 			var/server = query_get_messages.item[7]
 			var/editor_ckey = query_get_messages.item[8]
+			var/round_id = query_get_messages.item[9]
 			var/data
-			data += "<b>[timestamp] | [server] | [admin_ckey]</b>"
+			data += "<b>[timestamp] | [server] | [admin_ckey] | Round: [round_id]</b>"
 			if(!linkless)
 				data += " <a href='?_src_=holder;[HrefToken()];deletemessage=[id]'>\[Delete\]</a>"
 				if(type == "note")


### PR DESCRIPTION
Starts logging round ID when notes are created. SQL required.

This will make it faster for admins to look through logs for unban appeals etc.

🆑Birdtalon
rscadd: Logs round id in player notes
/🆑 