### PR TITLE
Autolathe href exploit fix, ported from TG.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -166,6 +166,7 @@
 
 			var/multiplier = text2num(href_list["multiplier"])
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
+			multiplier = CLAMP(multiplier,1,50)
 
 			/////////////////
 


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/38624

🆑 CitrusGender
fix: added a clamp so you can't set a negative multiplier to create materials and create more than 50 items.
/🆑