### PR TITLE
Genpop and Processing added to pubby station

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1809,15 +1809,6 @@
 "aem" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"aen" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aeo" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/potato,
@@ -1865,19 +1856,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/security/prison)
-"aes" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteenXnineteen,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel/black,
 /area/security/prison)
@@ -2079,10 +2057,6 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/barber,
-/area/security/prison)
-"aeX" = (
-/obj/machinery/washing_machine,
 /turf/open/floor/plasteel/barber,
 /area/security/prison)
 "aeY" = (
@@ -2716,16 +2690,12 @@
 /turf/closed/wall,
 /area/security/prison)
 "agz" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "permacell2";
-	name = "cell blast door"
-	},
-/obj/machinery/door/airlock/glass{
-	id_tag = "permabolt2";
-	name = "Cell 2"
+/obj/machinery/door/airlock/glass_security{
+	name = "Long-Term Cell 1";
+	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -2737,13 +2707,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permacell1";
-	name = "cell blast door"
-	},
-/obj/machinery/door/airlock/glass{
-	id_tag = "permabolt1";
-	name = "Cell 1"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor{
+	id = "genpopdoor";
+	name = "Genpop Blast Door"
 	},
 /turf/open/floor/plasteel/vault,
 /area/security/prison)
@@ -2802,22 +2769,25 @@
 /turf/open/floor/plasteel/black,
 /area/security/execution/transfer)
 "agI" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell 2";
-	network = list("SS13","Prison")
-	},
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/button/flasher{
+	id = "PCell 2";
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "permacell2";
+	name = "Cell 2 Lockdown";
+	pixel_x = 4;
+	pixel_y = 34;
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
 /area/security/prison)
 "agJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -2844,51 +2814,18 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agL" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell 1";
-	network = list("SS13","Prison")
-	},
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/security/prison)
-"agM" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/security/prison)
-"agN" = (
-/obj/machinery/light/small{
+/turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "permabolt1";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	req_access_txt = "0";
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agO" = (
 /obj/structure/sink{
@@ -2979,21 +2916,13 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agZ" = (
-/obj/machinery/flasher{
-	id = "PCell 1";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/floorgrime,
-/area/security/prison)
-"aha" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ahb" = (
 /obj/structure/toilet{
@@ -3001,33 +2930,9 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"ahc" = (
-/obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "ahd" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"ahe" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 2
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"ahf" = (
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"ahg" = (
-/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahh" = (
@@ -3061,6 +2966,7 @@
 /obj/item/clothing/mask/balaclava,
 /obj/item/device/mmi,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/item/melee/chainofcommand,
 /turf/open/floor/plasteel/black,
 /area/security/execution/transfer)
 "ahk" = (
@@ -3070,6 +2976,9 @@
 	},
 /obj/item/device/taperecorder{
 	pixel_x = -3
+	},
+/obj/item/razor{
+	pixel_x = -6
 	},
 /turf/open/floor/plasteel/black,
 /area/security/execution/transfer)
@@ -3090,12 +2999,9 @@
 /turf/open/floor/plasteel/black,
 /area/security/execution/transfer)
 "ahm" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Long-Term Cell 2";
-	req_access_txt = "2"
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -3104,23 +3010,23 @@
 /turf/closed/wall,
 /area/security/prison)
 "aho" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/security/prison)
-"ahp" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Long-Term Cell 1";
-	req_access_txt = "2"
-	},
+/obj/structure/window/reinforced,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel/red/side,
+/area/security/prison)
+"ahp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
 /area/security/prison)
 "ahq" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -3210,37 +3116,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/security/prison)
 "ahC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "PCell 2";
-	pixel_x = 5;
-	pixel_y = 24
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/machinery/button/door{
-	id = "permacell2";
-	name = "Cell 2 Lockdown";
-	pixel_x = 4;
-	pixel_y = 34;
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/red/corner{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/security/prison)
 "ahD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
 /area/security/prison)
 "ahE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3251,46 +3155,34 @@
 	},
 /area/security/prison)
 "ahF" = (
-/obj/machinery/camera{
-	c_tag = "Brig Prison Hallway";
-	network = list("SS13","Prison")
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("Prison");
-	pixel_y = 30
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/chair,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/security/prison)
 "ahG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "PCell 1";
-	pixel_x = 5;
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/machinery/button/door{
-	id = "permacell1";
-	name = "Cell 1 Lockdown";
-	pixel_x = 4;
-	pixel_y = 34;
-	req_access_txt = "2"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/red/corner{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/security/prison)
@@ -3324,24 +3216,24 @@
 	},
 /area/security/prison)
 "ahJ" = (
-/obj/machinery/power/apc/highcap/five_k{
+/obj/structure/window/reinforced{
 	dir = 1;
-	name = "Prison Wing APC";
-	pixel_x = 1;
-	pixel_y = 24
+	pixel_y = 1
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
 /area/security/prison)
 "ahK" = (
-/obj/structure/table,
-/obj/item/melee/chainofcommand,
-/turf/open/floor/plasteel/red/side{
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
 /area/security/prison)
@@ -3447,6 +3339,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/item/device/electropack,
+/obj/item/device/assembly/signaler{
+	pixel_x = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -3569,17 +3465,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aih" = (
-/obj/structure/table,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/item/device/assembly/signaler{
-	pixel_x = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
 /area/security/prison)
 "aii" = (
 /obj/structure/table,
@@ -3731,13 +3621,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
 /area/security/prison)
 "aiG" = (
 /obj/structure/cable{
@@ -3754,22 +3647,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aiI" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 6
-	},
-/area/security/prison)
 "aiJ" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/red/side,
+/turf/open/floor/plasteel/darkred/side,
 /area/security/prison)
 "aiK" = (
-/obj/structure/table,
-/obj/item/device/electropack,
-/turf/open/floor/plasteel/red/side,
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/darkred/side,
 /area/security/prison)
 "aiL" = (
 /obj/structure/table,
@@ -3910,10 +3800,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/security/execution/transfer)
-"ajc" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/black,
-/area/security/prison)
 "ajd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
@@ -3925,12 +3811,14 @@
 /area/security/prison)
 "aje" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
 /area/security/prison)
 "ajf" = (
 /obj/machinery/door/firedoor,
@@ -4120,13 +4008,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ajv" = (
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"ajw" = (
-/obj/machinery/vending/boozeomat{
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1, /obj/item/reagent_containers/food/drinks/bottle/absinthe = 1, /obj/item/reagent_containers/food/drinks/bottle/limejuice = 1, /obj/item/reagent_containers/food/drinks/bottle/cream = 1, /obj/item/reagent_containers/food/drinks/soda_cans/tonic = 1, /obj/item/reagent_containers/food/drinks/drinkingglass = 10, /obj/item/reagent_containers/food/drinks/ice = 3, /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6, /obj/item/reagent_containers/food/drinks/flask = 1);
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel/bar,
 /area/maintenance/department/crew_quarters/dorms)
 "ajx" = (
 /obj/machinery/door/poddoor/shutters{
@@ -4455,16 +4336,6 @@
 	icon_state = "floor5"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"aki" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plating{
-	burnt = 1;
-	icon_state = "panelscorched"
-	},
 /area/maintenance/department/crew_quarters/dorms)
 "akj" = (
 /obj/structure/cable{
@@ -4913,18 +4784,6 @@
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/stack/spacecash/c20,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"ald" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/gin{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ale" = (
@@ -5643,10 +5502,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
-"amE" = (
-/obj/item/cigbutt/roach,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/dorms)
 "amF" = (
 /turf/open/floor/wood{
 	broken = 1;
@@ -5934,10 +5789,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ann" = (
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/pod_1)
-"ano" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
 /area/shuttle/pod_1)
 "anp" = (
 /obj/structure/cable{
@@ -6294,17 +6145,6 @@
 "anY" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/dorms)
-"anZ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/crew_quarters/dorms)
-"aoa" = (
-/obj/structure/grille/broken,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -7305,8 +7145,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -7608,24 +7448,6 @@
 /obj/machinery/washing_machine,
 /obj/machinery/airalarm{
 	pixel_y = 22
-	},
-/turf/open/floor/plasteel/barber,
-/area/crew_quarters/dorms)
-"aqW" = (
-/obj/structure/table,
-/obj/item/clothing/under/color/grey,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Dormitory APC";
-	areastring = "/area/crew_quarters/dorms";
-	pixel_y = 25
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
@@ -8214,13 +8036,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
-"ask" = (
-/obj/item/clothing/under/kilt,
-/obj/item/clothing/head/collectable/wizard,
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "asl" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -8344,27 +8159,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
-	},
-/turf/open/floor/plasteel/red/side,
-/area/security/brig)
-"asz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
@@ -8674,23 +8473,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/teleporter)
-"ate" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Dormitory Maintenance APC";
-	areastring = "/area/maintenance/department/crew_quarters/dorms";
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating{
-	burnt = 1;
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/dorms)
 "atf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8795,49 +8577,38 @@
 /turf/open/space,
 /area/security/brig)
 "atv" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
 /area/security/brig)
 "atw" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Processing";
+	req_access_txt = "2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "atx" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Processing";
+	req_access_txt = "2"
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
 /area/security/brig)
 "aty" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/closed/wall,
 /area/security/brig)
@@ -8855,16 +8626,18 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "atA" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Processing";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
 /area/security/brig)
 "atB" = (
 /obj/structure/cable{
@@ -8918,15 +8691,14 @@
 /area/security/brig)
 "atF" = (
 /obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+/obj/machinery/turnstile{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/security/brig)
 "atG" = (
 /obj/machinery/door/airlock/glass_security{
@@ -9297,7 +9069,8 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "auy" = (
-/turf/open/floor/plasteel/floorgrime,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auz" = (
 /obj/machinery/light/small{
@@ -9729,42 +9502,35 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "avs" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
+/obj/structure/table,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/item/bedsheet/blue,
-/turf/open/floor/plasteel/blue/side,
 /area/security/brig)
 "avt" = (
-/turf/open/floor/plasteel/blue/side,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "avu" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "avv" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -28
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/bedsheet/green,
-/turf/open/floor/plasteel/green/side,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "avw" = (
-/turf/open/floor/plasteel/green/side,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "avx" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/structure/table,
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/green/side,
 /area/security/brig)
 "avy" = (
 /obj/structure/bed,
@@ -10363,17 +10129,17 @@
 	},
 /area/security/brig)
 "awM" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
 /area/security/brig)
 "awN" = (
 /obj/machinery/door/firedoor,
@@ -10644,13 +10410,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"axs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "axt" = (
@@ -11017,16 +10776,6 @@
 "ayo" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"ayp" = (
-/obj/structure/table/wood,
-/obj/item/pen{
-	layer = 4
-	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ayq" = (
@@ -11562,14 +11311,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"azw" = (
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "azx" = (
 /obj/structure/table/wood,
 /obj/item/device/paicard,
@@ -11583,12 +11324,6 @@
 /obj/item/toy/cards/deck{
 	pixel_x = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"azz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -12143,12 +11878,6 @@
 /area/crew_quarters/dorms)
 "aAQ" = (
 /obj/structure/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"aAR" = (
-/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -14160,11 +13889,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aEX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aEY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
@@ -15611,18 +15335,6 @@
 /obj/effect/decal/cleanable/deadcockroach,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
-"aIn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/toilet/restrooms)
 "aIo" = (
 /obj/structure/mineral_door/iron,
 /turf/open/floor/plating,
@@ -16036,17 +15748,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aJg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aJh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16557,17 +16258,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aKc" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"aKd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aKe" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Hallway";
@@ -16856,18 +16546,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"aKW" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Bridge";
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/maintenance/department/crew_quarters/bar)
-"aKX" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/maintenance/department/crew_quarters/bar)
 "aKY" = (
 /turf/closed/wall/r_wall,
 /area/storage/eva)
@@ -17135,15 +16813,6 @@
 /obj/structure/closet/coffin,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aLJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "aLK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
@@ -17152,38 +16821,6 @@
 /area/maintenance/department/crew_quarters/bar)
 "aLL" = (
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aLM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/bar)
-"aLN" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aLO" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating{
-	burnt = 1;
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/bar)
-"aLP" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg3"
-	},
 /area/maintenance/department/crew_quarters/bar)
 "aLQ" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -17883,36 +17520,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aNk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aNl" = (
-/obj/item/trash/pistachios,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aNm" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aNn" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aNo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg3"
-	},
 /area/maintenance/department/crew_quarters/bar)
 "aNp" = (
 /obj/structure/rack{
@@ -20483,20 +20093,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aSU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aSV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -21114,15 +20710,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aUh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Theatre Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "12;46"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aUi" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Cargo";
@@ -21569,11 +21156,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"aVe" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
 "aVf" = (
@@ -22149,12 +21731,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"aWk" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
 "aWl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/black,
@@ -22477,15 +22053,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"aWZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "aXa" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -22525,60 +22092,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"aXe" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8;
-	light_color = "#2cb2e8"
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"aXf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/festivus,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"aXg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
 "aXh" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"aXi" = (
-/obj/structure/festivus,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"aXj" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#b4f237"
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "aXk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -22958,16 +22475,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/kitchen)
-"aYc" = (
-/obj/machinery/door/airlock{
-	cyclelinkeddir = 4;
-	name = "Bar Access";
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "aYd" = (
 /obj/machinery/door/airlock{
 	cyclelinkeddir = 8;
@@ -23336,23 +22843,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"aYW" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/machinery/button/door{
-	dir = 2;
-	id = "barshutters";
-	name = "Bar Lockdown";
-	pixel_x = 6;
-	pixel_y = 27;
-	req_access_txt = "7; 29"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -5;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "aYX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -23904,13 +23394,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"baf" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "bag" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -23918,45 +23401,6 @@
 /area/crew_quarters/bar)
 "bah" = (
 /turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"bai" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
-"baj" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
-"bak" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/landmark/xmastree,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
-"bal" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
-"bam" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/crew_quarters/bar)
 "ban" = (
 /obj/structure/disposalpipe/segment,
@@ -24409,23 +23853,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bbj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/crew_quarters/kitchen)
-"bbk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "bbl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -24440,13 +23867,6 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"bbn" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/crew_quarters/bar)
 "bbo" = (
 /obj/item/clothing/head/hardhat/cakehat,
@@ -24818,35 +24238,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bci" = (
-/obj/machinery/newscaster{
-	pixel_y = 1
-	},
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
-"bcj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
 "bck" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"bcl" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/crew_quarters/bar)
 "bcm" = (
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"bcn" = (
-/mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
 "bco" = (
@@ -24858,12 +24255,6 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/bar)
-"bcp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
 	},
@@ -25309,32 +24700,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bds" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"bdt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/clothing/head/hardhat/cakehat,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/crew_quarters/bar)
-"bdu" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/crew_quarters/bar)
 "bdv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25781,16 +25146,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bet" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "beu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -25798,20 +25153,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bev" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"bew" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/crew_quarters/bar)
 "bex" = (
 /obj/machinery/camera{
 	c_tag = "Bar Port";
@@ -26609,15 +25950,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"bgm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/kitchen)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -26894,10 +26226,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"bgT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bgU" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
@@ -27868,13 +27196,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
-"biQ" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-05";
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/blue/side,
-/area/hallway/primary/central)
 "biR" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -28618,12 +27939,6 @@
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
-"bkU" = (
-/turf/closed/wall/r_wall,
-/area/construction/mining/aux_base/closet)
-"bkV" = (
-/turf/closed/wall,
-/area/construction/mining/aux_base/closet)
 "bkW" = (
 /obj/item/hemostat,
 /obj/item/retractor,
@@ -29375,17 +28690,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bmE" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
-	},
-/area/science/research/lobby)
-"bmF" = (
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
-	},
-/area/science/research/lobby)
 "bmG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -29406,11 +28710,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/research/lobby)
-"bmK" = (
-/turf/open/floor/plasteel/purple/side{
-	dir = 4
-	},
 /area/science/research/lobby)
 "bmL" = (
 /obj/structure/rack{
@@ -29818,16 +29117,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side,
-/area/science/research/lobby)
-"bnJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/science/research/lobby)
-"bnK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/research/lobby)
 "bnL" = (
 /obj/structure/disposalpipe/segment{
@@ -30317,12 +29606,6 @@
 	dir = 8
 	},
 /area/science/research/lobby)
-"boV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/corner{
-	dir = 8
-	},
-/area/science/research/lobby)
 "boW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -30698,17 +29981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/medical/morgue)
-"bpL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
@@ -37705,18 +36977,6 @@
 	dir = 4
 	},
 /area/security/checkpoint/science)
-"bDJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/research/lobby)
 "bDK" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -37969,10 +37229,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bEi" = (
-/obj/structure/transit_tube,
-/turf/open/space,
-/area/space)
 "bEj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
 	dir = 8
@@ -39234,10 +38490,6 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space)
-"bGJ" = (
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space)
 "bGK" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating{
@@ -39738,11 +38990,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bHO" = (
-/obj/structure/transit_tube,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/black,
@@ -39775,14 +39022,6 @@
 "bHV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 1
-	},
-/area/medical/virology)
-"bHW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
@@ -40099,15 +39338,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/science/research/lobby)
-"bIB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/research/lobby)
@@ -41054,17 +40284,10 @@
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
-"bKL" = (
-/obj/structure/sign/science,
-/turf/closed/wall,
-/area/maintenance/department/engine/atmos)
 "bKM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"bKN" = (
-/turf/closed/wall,
-/area/maintenance/department/engine/atmos)
 "bKO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -41846,13 +41069,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"bMz" = (
-/obj/structure/transit_tube/curved{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -41924,14 +41140,6 @@
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
 	},
-/area/medical/medbay/central)
-"bML" = (
-/obj/machinery/light,
-/obj/item/soap/nanotrasen,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bMM" = (
 /obj/structure/closet/l3closet,
@@ -42263,22 +41471,6 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
-"bNC" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/space/basic,
-/area/space)
-"bND" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"bNE" = (
-/obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
-	dir = 8
-	},
-/turf/open/space/basic,
 /area/space)
 "bNF" = (
 /obj/item/stack/medical/bruise_pack,
@@ -42935,12 +42127,6 @@
 "bPh" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"bPi" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "bPj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -45055,11 +44241,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"bTZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "bUa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -45693,9 +44874,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bVq" = (
-/turf/closed/wall,
-/area/space)
 "bVr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
@@ -45833,10 +45011,6 @@
 	},
 /area/crew_quarters/heads/chief)
 "bVE" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"bVF" = (
-/obj/effect/landmark/start/chief_engineer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVG" = (
@@ -46492,17 +45666,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"bWU" = (
-/obj/structure/flora/ausbushes,
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Port Fore";
-	dir = 1;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "bWV" = (
 /turf/closed/wall,
 /area/chapel/main/monastery)
@@ -46525,18 +45688,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"bWY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/turf/open/floor/plating,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "bWZ" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -46797,12 +45948,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"bXH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "bXI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46812,13 +45957,6 @@
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "bXJ" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"bXK" = (
-/obj/item/device/radio/beacon,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "bXL" = (
@@ -46845,36 +45983,6 @@
 /area/chapel/asteroid{
 	name = "Monastery Asteroid"
 	})
-"bXO" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"bXP" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"bXQ" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"bXR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "bXS" = (
 /obj/structure/grille/broken,
 /obj/machinery/disposal/bin,
@@ -47067,14 +46175,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"bYr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bYs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -47114,13 +46214,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"bYy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "bYz" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -47137,29 +46230,6 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
-"bYC" = (
-/obj/structure/chair,
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/chapel/main/monastery)
-"bYD" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space)
-"bYE" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "bYF" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -47657,10 +46727,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"bZk" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "bZl" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/chapel{
@@ -47683,19 +46749,6 @@
 /area/chapel/main/monastery)
 "bZo" = (
 /turf/open/floor/carpet,
-/area/chapel/main/monastery)
-"bZp" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main/monastery)
-"bZq" = (
-/obj/structure/chair,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
 "bZr" = (
 /obj/item/trash/tray,
@@ -47972,28 +47025,8 @@
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"bZW" = (
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Port";
-	dir = 1;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"bZX" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "bZY" = (
 /turf/closed/wall,
-/area/chapel/office)
-"bZZ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/black,
 /area/chapel/office)
 "caa" = (
 /obj/structure/disposalpipe/segment,
@@ -48433,12 +47466,6 @@
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"caU" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "caV" = (
 /obj/machinery/holopad,
 /obj/item/device/flashlight/lantern,
@@ -48450,26 +47477,6 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"caX" = (
-/obj/structure/chair,
-/obj/machinery/camera{
-	c_tag = "Chapel";
-	dir = 8;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plasteel/chapel,
-/area/chapel/main/monastery)
-"caY" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Starboard";
-	dir = 1;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -48746,65 +47753,11 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
-"cbH" = (
-/obj/structure/closet{
-	name = "chaplain closet"
-	},
-/obj/item/clothing/under/rank/chaplain,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/storage/backpack/cultpack,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/clothing/suit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/holidaypriest,
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/chapel/office)
-"cbI" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet,
-/area/chapel/office)
-"cbJ" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-18";
-	layer = 4.1;
-	pixel_y = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/carpet,
-/area/chapel/office)
 "cbK" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cbL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
 /area/chapel/main/monastery)
 "cbM" = (
 /turf/open/floor/plasteel/chapel{
@@ -48831,14 +47784,6 @@
 "cbP" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
-	},
-/area/chapel/main/monastery)
-"cbQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 4
 	},
 /area/chapel/main/monastery)
 "cbR" = (
@@ -49051,12 +47996,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"cct" = (
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "ccu" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/asteroid,
@@ -49069,90 +48008,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
-"ccw" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/chapel/office)
-"ccx" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	name = "flask of holy water";
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/nullrod,
-/turf/open/floor/carpet,
-/area/chapel/office)
-"ccy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ccz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ccA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_y = 26
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Port Access";
-	dir = 2;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ccB" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Access";
-	opacity = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ccC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main/monastery)
-"ccD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/chapel,
-/area/chapel/main/monastery)
 "ccE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49171,23 +48026,8 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
-"ccG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main/monastery)
 "ccH" = (
 /turf/open/floor/plasteel/chapel,
-/area/chapel/main/monastery)
-"ccI" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Access";
-	opacity = 1
-	},
-/turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "ccJ" = (
 /obj/machinery/light/small{
@@ -49196,17 +48036,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/airalarm{
 	pixel_y = 22
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ccK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Starboard Access";
-	dir = 2;
-	network = list("SS13","Monastery")
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -49489,13 +48318,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
-"cdn" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/chapel/office)
 "cdo" = (
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -49530,34 +48352,9 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cdt" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "cdu" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 8
-	},
-/area/chapel/main/monastery)
-"cdv" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
 	},
 /area/chapel/main/monastery)
 "cdw" = (
@@ -49567,23 +48364,6 @@
 "cdx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cdy" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/candle_box,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/chapel/main/monastery)
-"cdz" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-08";
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
 /area/chapel/main/monastery)
 "cdA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49889,10 +48669,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cem" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/chapel/main/monastery)
 "cen" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -50030,14 +48806,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
-"ceD" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Crematorium";
-	opacity = 1;
-	req_access = "27"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "ceE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
@@ -50048,10 +48816,6 @@
 	dir = 8
 	},
 /area/chapel/office)
-"ceG" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "ceH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -50060,23 +48824,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ceI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -50118,15 +48865,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"ceO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "ceP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50139,14 +48877,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"ceR" = (
-/obj/machinery/field/generator,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"ceS" = (
-/obj/machinery/power/emitter,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "ceT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/line{
@@ -50260,23 +48990,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cfh" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"cfi" = (
-/obj/machinery/button/crematorium{
-	id = "foo";
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"cfj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall,
-/area/chapel/office)
 "cfk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50319,13 +49032,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/chapel/main/monastery)
-"cfq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
 /area/chapel/main/monastery)
 "cfr" = (
 /obj/structure/transit_tube_pod,
@@ -50425,17 +49131,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cfA" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cfB" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
 "cfC" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/hydrofloor,
@@ -50613,23 +49308,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cga" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Monastery External APC";
-	areastring = "/area/chapel/main/monastery";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/asteroid{
-	icon_plating = "asteroid"
-	},
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "cgb" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -50637,23 +49315,9 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
-"cgc" = (
-/obj/item/seeds/wheat,
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
 "cgd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cge" = (
-/obj/item/storage/bag/plants,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
@@ -50671,10 +49335,6 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"cgh" = (
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
 "cgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50696,14 +49356,6 @@
 	c_tag = "Monastery Garden";
 	dir = 2;
 	network = list("SS13","Monastery")
-	},
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cgl" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/carrot,
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -50795,86 +49447,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cgy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/asteroid{
-	icon_plating = "asteroid"
-	},
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cgz" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
-"cgA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
-"cgB" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
-"cgC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cgD" = (
-/obj/machinery/vending/hydronutrients,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cgE" = (
-/obj/item/shovel/spade,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cgF" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
 "cgG" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -51057,17 +49629,6 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
-"che" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
 "chf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51079,38 +49640,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"chg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"chh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/chapel/main/monastery)
 "chi" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -51134,14 +49663,6 @@
 "chl" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"chm" = (
-/obj/machinery/door/airlock{
-	name = "Garden"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/hydroponics/garden/monastery)
 "chn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -51289,16 +49810,6 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"chH" = (
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"chI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "chJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51446,24 +49957,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"cie" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cif" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Monastery Cells";
-	dir = 8;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "cig" = (
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plating/airless,
@@ -51604,22 +50097,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"ciB" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ciC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "ciD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51678,34 +50155,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"ciL" = (
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Coffin Storage";
-	req_one_access_txt = "22"
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ciM" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "ciN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/black,
@@ -51721,27 +50170,6 @@
 	pixel_x = 5;
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ciP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ciQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "ciR" = (
@@ -51764,18 +50192,6 @@
 /obj/item/seeds/harebell,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"ciU" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "ciV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -51873,21 +50289,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cjh" = (
-/obj/machinery/door/airlock/external{
-	name = "Dock Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cji" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "cjj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -51912,20 +50313,6 @@
 /area/chapel/main/monastery)
 "cjm" = (
 /turf/closed/wall,
-/area/maintenance/department/chapel/monastery)
-"cjn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Monastery Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "22;24;10;11"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cjo" = (
 /obj/machinery/hydroponics/soil,
@@ -52050,42 +50437,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"cjD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Secondary Dock";
-	dir = 8;
-	network = list("SS13","Monastery")
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cjE" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cjF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/chapel/main/monastery)
-"cjG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "cjH" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Garden";
@@ -52093,69 +50444,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cjI" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/closed/wall,
-/area/maintenance/department/chapel/monastery)
-"cjJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cjK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cjL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery Maintenance APC";
-	areastring = "/area/maintenance/department/chapel/monastery";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cjM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cjN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/storage/box/lights/bulbs,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
 "cjO" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -52193,25 +50481,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
-/area/library)
-"cjS" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library APC";
-	areastring = "/area/library";
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/black,
 /area/library)
 "cjT" = (
 /obj/structure/grille,
@@ -52369,10 +50638,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/library)
-"ckn" = (
-/obj/item/storage/bag/books,
-/turf/open/floor/plasteel/black,
-/area/library)
 "cko" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/black,
@@ -52438,14 +50703,6 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"ckx" = (
-/obj/structure/table/wood/fancy,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "cky" = (
@@ -52608,23 +50865,6 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"ckZ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/space,
-/area/space)
-"cla" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "clb" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -52632,16 +50872,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"clc" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space,
-/area/space)
 "cld" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -52670,12 +50900,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"clh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/library)
 "cli" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -52697,13 +50921,6 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/black,
 /area/library)
-"cll" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "clm" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/black,
@@ -52712,34 +50929,11 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/plasteel/black,
 /area/library)
-"clo" = (
-/obj/effect/decal/remains/human,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "clp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/black,
 /area/library)
-"clq" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/item/barcodescanner,
-/turf/open/floor/plasteel/black,
-/area/library)
-"clr" = (
-/obj/item/pickaxe/mini,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "cls" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/closed/mineral,
@@ -52875,12 +51069,6 @@
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"clO" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "clP" = (
 /obj/structure/transit_tube/station/reverse/flipped{
 	dir = 8
@@ -53338,12 +51526,6 @@
 	},
 /turf/open/floor/plasteel/black/telecomms,
 /area/tcommsat/server)
-"cmS" = (
-/turf/open/floor/plasteel/whitepurple/side/telecomms,
-/area/tcommsat/server)
-"cmT" = (
-/turf/open/floor/plasteel/darkgreen/side/telecomms,
-/area/tcommsat/server)
 "cmU" = (
 /obj/machinery/light{
 	dir = 4
@@ -53390,32 +51572,6 @@
 "cne" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"cnf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkblue/side/telecomms{
-	dir = 1
-	},
-/area/tcommsat/server)
-"cng" = (
-/turf/open/floor/plasteel/darkblue/side/telecomms{
-	dir = 1
-	},
-/area/tcommsat/server)
-"cnh" = (
-/turf/open/floor/plasteel/whitepurple/side/telecomms{
-	dir = 1
-	},
-/area/tcommsat/server)
-"cni" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitepurple/side/telecomms{
-	dir = 1
-	},
 /area/tcommsat/server)
 "cnj" = (
 /obj/machinery/telecomms/processor/preset_four,
@@ -53551,14 +51707,6 @@
 	},
 /turf/open/space,
 /area/space)
-"cnB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/purple/side{
-	dir = 4
-	},
-/area/science/research/lobby)
 "cnC" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -53578,9 +51726,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"cnF" = (
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/AIsatextAP)
 "cnG" = (
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -53589,26 +51734,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/AIsatextAS)
-"cnI" = (
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/AIsatextAS)
 "cnJ" = (
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"cnK" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"cnL" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"cnM" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -53625,11 +51752,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"cnO" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "cnP" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
@@ -53640,19 +51762,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"cnR" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "cnS" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
 "cnT" = (
-/obj/structure/weightlifter,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"cnU" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -53670,31 +51783,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"cnY" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/pod_1)
-"cnZ" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/pod_1)
-"coa" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/security/brig)
-"cob" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/security/brig)
-"coc" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/security/brig)
 "cod" = (
 /obj/structure/table,
 /obj/item/clothing/under/color/grey,
@@ -53728,15 +51816,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/crew_quarters/dorms)
-"cof" = (
-/turf/open/floor/plasteel/darkred/side,
-/area/security/brig)
-"cog" = (
-/turf/open/floor/plasteel/darkred/side,
-/area/security/brig)
-"coh" = (
-/turf/open/floor/plasteel/darkred/side,
-/area/security/brig)
 "coi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -53826,11 +51905,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"cox" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "coy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -53839,19 +51913,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/blue/corner{
-	dir = 8
-	},
-/area/hallway/primary/central)
-"coA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -53880,37 +51941,6 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
-"coC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/blue/corner{
-	dir = 8
-	},
-/area/hallway/primary/central)
-"coD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/blue/corner{
-	dir = 8
-	},
-/area/hallway/primary/central)
-"coE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/hallway/primary/central)
 "coF" = (
 /obj/structure/cable{
@@ -53955,34 +51985,7 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"coI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	burnt = 1;
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "coJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/bar)
-"coK" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -53999,35 +52002,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/quartermaster/storage)
-"coM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/quartermaster/storage)
 "coN" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/secondary/exit/departure_lounge)
-"coO" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/secondary/exit/departure_lounge)
-"coP" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/secondary/exit/departure_lounge)
-"coQ" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/secondary/exit/departure_lounge)
-"coR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/quartermaster/storage)
-"coS" = (
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "coT" = (
 /obj/item/device/radio/beacon,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"coU" = (
-/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "coV" = (
 /obj/machinery/vending/cigarette,
@@ -54043,25 +52023,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"coX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"coY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"coZ" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/secondary/exit/departure_lounge)
 "cpa" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -54102,10 +52063,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/bar)
-"cpd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "cpe" = (
 /obj/machinery/door/airlock{
 	cyclelinkeddir = 4;
@@ -54113,12 +52070,6 @@
 	req_access_txt = "25"
 	},
 /turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"cpf" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
 /area/crew_quarters/bar)
 "cpg" = (
 /obj/machinery/button/door{
@@ -54193,14 +52144,6 @@
 "cpo" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/black,
-/area/crew_quarters/bar)
-"cpp" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
 /area/crew_quarters/bar)
 "cpq" = (
 /obj/machinery/deepfryer,
@@ -54304,38 +52247,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"cpD" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"cpE" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"cpF" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"cpG" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "cpH" = (
 /turf/open/floor/plasteel{
 	icon_state = "L1"
@@ -54430,12 +52341,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"cpW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "cpX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -54456,11 +52361,6 @@
 	},
 /area/medical/medbay/central)
 "cqa" = (
-/turf/open/floor/plasteel/whiteblue/corner{
-	dir = 8
-	},
-/area/medical/medbay/central)
-"cqb" = (
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
@@ -54487,19 +52387,11 @@
 	dir = 1
 	},
 /area/medical/medbay/central)
-"cqg" = (
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 4
-	},
-/area/medical/medbay/central)
 "cqh" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/purple/corner,
 /area/science/research/lobby)
 "cqi" = (
-/turf/open/floor/plasteel/purple/side,
-/area/science/research/lobby)
-"cqj" = (
 /turf/open/floor/plasteel/purple/side,
 /area/science/research/lobby)
 "cqk" = (
@@ -54525,22 +52417,6 @@
 	dir = 4
 	},
 /area/medical/medbay/central)
-"cqn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whiteblue/corner{
-	dir = 4
-	},
-/area/medical/medbay/central)
-"cqo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whiteblue/corner{
-	dir = 4
-	},
-/area/medical/medbay/central)
 "cqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -54550,11 +52426,6 @@
 	},
 /area/science/research/lobby)
 "cqq" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/transport)
-"cqr" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -54577,14 +52448,6 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/purple/side,
-/area/science/research/lobby)
-"cqu" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/purple/side{
-	dir = 8
-	},
 /area/science/research/lobby)
 "cqv" = (
 /obj/structure/disposalpipe/segment,
@@ -54626,24 +52489,6 @@
 	},
 /turf/open/floor/plasteel/green/side,
 /area/science/research/lobby)
-"cqA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side,
-/area/science/research/lobby)
-"cqB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side,
-/area/science/research/lobby)
-"cqC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side,
-/area/science/research/lobby)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -54659,10 +52504,6 @@
 	},
 /turf/open/floor/plasteel/green/side,
 /area/science/research/lobby)
-"cqF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "cqG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -54682,50 +52523,10 @@
 	dir = 8
 	},
 /area/chapel/dock)
-"cqJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cqR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "cqS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/space)
-"cqT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "cqU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -54756,47 +52557,15 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"cqY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cqZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cra" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "crb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/chapel/office)
-"crc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"crd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "cre" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
-"crf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
 "crg" = (
@@ -54813,12 +52582,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
-"cri" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "crj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54848,30 +52611,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space,
 /area/space)
-"crn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"cro" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"crp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"crq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"crr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"crs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "crt" = (
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
@@ -54884,9 +52623,6 @@
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
 "crv" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"crw" = (
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
 "crx" = (
@@ -54974,10 +52710,6 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"crI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "crJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
@@ -55029,16 +52761,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"crP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/office)
-"crQ" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"crR" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "crS" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -55072,10 +52794,6 @@
 /area/chapel/asteroid{
 	name = "Monastery Asteroid"
 	})
-"crW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "crX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/black,
@@ -55091,24 +52809,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"crZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"csa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"csb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"csc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "csd" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -55155,16 +52855,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"csl" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"csm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "csn" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
@@ -55192,7 +52882,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 10
+	dir = 1
 	},
 /area/chapel/office)
 "csq" = (
@@ -55200,7 +52890,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 10
+	dir = 1
 	},
 /area/chapel/office)
 "csr" = (
@@ -55211,7 +52901,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 10
+	dir = 1
 	},
 /area/chapel/office)
 "css" = (
@@ -55219,23 +52909,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 10
+	dir = 1
 	},
-/area/chapel/office)
-"cst" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
-	},
-/area/chapel/office)
-"csu" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/chapel/office)
 "csv" = (
 /obj/machinery/light/small{
@@ -55244,16 +52919,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"csw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"csx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "csy" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -55269,10 +52934,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"csA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/office)
 "csB" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -55315,14 +52976,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/chapel/office)
-"csH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/darkred,
-/area/chapel/office)
 "csI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -55335,33 +52988,6 @@
 	req_access_txt = "22"
 	},
 /turf/open/floor/plasteel/black,
-/area/chapel/office)
-"csJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/asteroid,
-/area/chapel/office)
-"csK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/asteroid,
-/area/chapel/office)
-"csL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/asteroid,
 /area/chapel/office)
 "csM" = (
 /obj/structure/cable{
@@ -55401,27 +53027,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"csP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "csQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"csR" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -55454,16 +53060,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
-"csV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"csW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "csX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -55486,7 +53082,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 9
+	dir = 10
 	},
 /area/chapel/office)
 "cta" = (
@@ -55494,7 +53090,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 9
+	dir = 10
 	},
 /area/chapel/office)
 "ctb" = (
@@ -55502,23 +53098,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 9
-	},
-/area/chapel/office)
-"ctc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
-	},
-/area/chapel/office)
-"ctd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+	dir = 10
 	},
 /area/chapel/office)
 "cte" = (
@@ -55526,13 +53106,6 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/chapel/office)
-"ctf" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/chapel/office)
 "ctg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -55546,53 +53119,7 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cti" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"ctj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cto" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctp" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/chapel/office)
-"ctq" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/chapel/office)
 "ctr" = (
-/turf/open/floor/plasteel/darkyellow/corner{
-	tag = "icon-darkyellowcorners (EAST)";
-	icon_state = "darkyellowcorners";
-	dir = 4
-	},
-/area/chapel/office)
-"cts" = (
 /turf/open/floor/plasteel/darkyellow/corner{
 	tag = "icon-darkyellowcorners (EAST)";
 	icon_state = "darkyellowcorners";
@@ -55619,61 +53146,10 @@
 	dir = 4
 	},
 /area/chapel/office)
-"ctv" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ctw" = (
-/turf/closed/wall/mineral/iron,
-/area/chapel/main/monastery)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/mineral/iron,
 /area/chapel/main/monastery)
-"cty" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/mineral/iron,
-/area/chapel/main/monastery)
-"ctz" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"ctA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"ctB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/office)
-"ctE" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ctF" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ctG" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ctH" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
-"ctI" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "ctJ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
@@ -55770,12 +53246,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"ctR" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "ctS" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -55784,14 +53254,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
-"ctT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"ctU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "ctV" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/holidaypriest,
@@ -55820,25 +53282,6 @@
 	dir = 8
 	},
 /area/chapel/office)
-"ctY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/chapel/main/monastery)
-"ctZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/chapel/main/monastery)
 "cua" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -55847,46 +53290,6 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"cub" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"cuc" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
-"cud" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
-"cue" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cuf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cug" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cuh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cui" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
-"cuj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "cuk" = (
 /obj/structure/closet{
 	name = "beekeeping wardrobe"
@@ -55935,17 +53338,6 @@
 /obj/item/seeds/watermelon/holy,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"cuq" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cur" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "cus" = (
 /obj/structure/closet{
 	name = "beekeeping supplies"
@@ -56038,24 +53430,7 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"cuC" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/beebox,
-/obj/item/queen_bee/bought,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cuD" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
 "cuE" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/carrot,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cuF" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
 /turf/open/floor/grass,
@@ -56090,17 +53465,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cuL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/chapel/main/monastery)
 "cuM" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -56115,10 +53479,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
-"cuN" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -56156,12 +53516,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cuT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -56224,12 +53578,6 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
-"cva" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "cvb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat,
@@ -56256,11 +53604,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cvf" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/harebell,
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
 "cvg" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -56296,28 +53639,6 @@
 	network = list("SS13","Monastery")
 	},
 /turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cvl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/mineral/iron,
-/area/chapel/main/monastery)
-"cvm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
 "cvq" = (
 /obj/machinery/camera{
@@ -56391,26 +53712,12 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
-"cvx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/chapel/main/monastery)
 "cvy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
-	},
-/area/chapel/main/monastery)
-"cvz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/chapel/main/monastery)
 "cvA" = (
@@ -56437,12 +53744,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cvD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/mineral/iron,
-/area/chapel/main/monastery)
 "cvE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56457,19 +53758,6 @@
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "cvF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/chapel/main/monastery)
-"cvG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -56566,22 +53854,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
-"cvN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cvQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
 "cvR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -56609,19 +53881,9 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
-"cvU" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet,
-/area/chapel/main/monastery)
 "cvV" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cvW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
 "cvX" = (
@@ -56651,9 +53913,6 @@
 "cwa" = (
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
-"cwb" = (
-/turf/closed/wall/mineral/iron,
-/area/maintenance/department/chapel/monastery)
 "cwc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56668,13 +53927,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"cwd" = (
-/turf/closed/wall/mineral/iron,
-/area/maintenance/department/chapel/monastery)
 "cwe" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwf" = (
 /turf/closed/wall/mineral/iron,
 /area/library)
 "cwg" = (
@@ -56688,12 +53941,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/library)
-"cwh" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwi" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cwj" = (
 /obj/item/storage/box/matches{
@@ -56775,9 +54022,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"cwq" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
 "cwr" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -56795,18 +54039,6 @@
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/black,
-/area/library)
-"cws" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwt" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwu" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwv" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cww" = (
 /obj/structure/table/wood,
@@ -56844,18 +54076,6 @@
 "cwA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"cwB" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwC" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
 "cwE" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56886,20 +54106,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"cwI" = (
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"cwJ" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
 "cwK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/library)
-"cwL" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cwM" = (
 /obj/structure/window/reinforced{
@@ -56908,21 +54119,9 @@
 	},
 /turf/open/space,
 /area/space)
-"cwN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
 "cwO" = (
 /obj/item/device/flashlight/lantern,
 /turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cwP" = (
-/obj/item/device/flashlight/lantern,
-/turf/open/floor/plasteel/black,
-/area/chapel/main/monastery)
-"cwQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
 "cwR" = (
 /obj/structure/window/reinforced{
@@ -56935,59 +54134,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"cwT" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
 "cwU" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/plasteel/black,
-/area/library)
-"cwV" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cwW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cwX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cwY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cwZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cxa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cxb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cxc" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space)
-"cxd" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cxe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/library)
-"cxf" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cxg" = (
 /obj/structure/window/reinforced{
@@ -57007,14 +54163,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"cxi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
-"cxj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/main/monastery)
 "cxk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -57026,16 +54174,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"cxl" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space/basic,
-/area/space)
-"cxm" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
 "cxn" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
@@ -57044,56 +54182,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/library)
-"cxo" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxp" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space/basic,
-/area/space)
-"cxq" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space/basic,
-/area/space)
-"cxr" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxs" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxt" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxu" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxv" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxw" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxx" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
-"cxy" = (
-/turf/closed/wall/mineral/iron,
-/area/library)
 "cxz" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/library)
-"cxA" = (
-/turf/closed/wall/mineral/iron,
 /area/library)
 "cxB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57140,13 +54234,6 @@
 "cxG" = (
 /turf/open/space/basic,
 /area/library)
-"cxH" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cxI" = (
-/turf/open/space/basic,
-/area/library)
 "cxJ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57176,42 +54263,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/library)
-"cxN" = (
-/turf/open/space/basic,
-/area/library)
-"cxO" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cxP" = (
-/turf/open/space/basic,
-/area/library)
-"cxQ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cxR" = (
-/turf/open/space/basic,
-/area/library)
-"cxS" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cxT" = (
-/turf/open/space/basic,
-/area/library)
-"cxU" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cxV" = (
-/turf/open/space/basic,
-/area/library)
-"cxW" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/library)
 "cxX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57236,50 +54287,6 @@
 	dir = 1
 	},
 /area/library)
-"cxZ" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/library)
-"cya" = (
-/turf/open/space/basic,
-/area/library)
-"cyb" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyc" = (
-/turf/open/space/basic,
-/area/library)
-"cyd" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cye" = (
-/turf/open/space/basic,
-/area/library)
-"cyf" = (
-/turf/open/space/basic,
-/area/library)
-"cyg" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyh" = (
-/turf/open/space/basic,
-/area/library)
-"cyi" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyj" = (
-/turf/open/space/basic,
-/area/library)
-"cyk" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/library)
 "cyl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57296,45 +54303,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
-"cyn" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/library)
-"cyo" = (
-/turf/open/space/basic,
-/area/library)
-"cyp" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyq" = (
-/turf/open/space/basic,
-/area/library)
-"cyr" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cys" = (
-/turf/open/space/basic,
-/area/library)
-"cyt" = (
-/turf/open/space/basic,
-/area/library)
-"cyu" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyv" = (
-/turf/open/space/basic,
-/area/library)
-"cyw" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyx" = (
-/turf/open/space/basic,
 /area/library)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57374,37 +54342,6 @@
 	},
 /turf/closed/wall,
 /area/library)
-"cyC" = (
-/turf/open/space/basic,
-/area/library)
-"cyD" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyE" = (
-/turf/open/space/basic,
-/area/library)
-"cyF" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
-"cyG" = (
-/turf/open/space/basic,
-/area/library)
-"cyH" = (
-/turf/open/space/basic,
-/area/library)
-"cyI" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/library)
-"cyJ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/library)
 "cyK" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -57422,14 +54359,6 @@
 /area/chapel/asteroid{
 	name = "Monastery Asteroid"
 	})
-"cyN" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cyO" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cyP" = (
 /obj/structure/bookcase/random/nonfiction,
 /obj/machinery/light/small{
@@ -57475,20 +54404,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/library)
-"cyV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cyW" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cyX" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cyY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57499,63 +54414,7 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/black,
 /area/library)
-"cza" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/plasteel/black,
-/area/library)
-"czb" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/plasteel/black,
-/area/library)
-"czc" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/plasteel/black,
-/area/library)
-"czd" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cze" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"czf" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"czg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"czh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"czi" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"czj" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"czk" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "czl" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet,
-/area/library)
-"czm" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet,
-/area/library)
-"czn" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/carpet,
 /area/library)
@@ -57620,20 +54479,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"czx" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"czy" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"czz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
 "czA" = (
 /obj/structure/table/wood/fancy,
 /obj/item/dice/d20,
@@ -57658,20 +54503,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/black,
 /area/library)
-"czE" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
-"czF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"czG" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "czH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57684,18 +54515,6 @@
 /turf/open/floor/plasteel/black,
 /area/library)
 "czI" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
-"czJ" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
-"czK" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
@@ -57736,24 +54555,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"czR" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"czS" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"czT" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"czU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
 "czV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -57761,12 +54562,6 @@
 /turf/open/floor/plasteel/black,
 /area/library)
 "czW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
-"czX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -57790,32 +54585,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"cAb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
-"cAc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAd" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cAe" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cAf" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
 "cAg" = (
 /turf/open/floor/plasteel/vault,
 /area/library)
@@ -57835,38 +54604,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/library)
-"cAk" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/library)
-"cAl" = (
-/turf/open/floor/plasteel/vault,
-/area/library)
-"cAm" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
-"cAn" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cAo" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cAp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
 /area/library)
 "cAr" = (
 /obj/machinery/light/small{
@@ -57917,26 +54654,6 @@
 	dir = 5
 	},
 /area/library)
-"cAw" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lantern{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/library)
-"cAx" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-05";
-	layer = 4.1;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/library)
 "cAy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -57949,14 +54666,6 @@
 	req_access_txt = "37"
 	},
 /turf/open/floor/plasteel/darkred/side,
-/area/library)
-"cAz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
 /area/library)
 "cAB" = (
 /turf/open/floor/plasteel/darkpurple/side{
@@ -57980,28 +54689,9 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/plasteel/black,
 /area/library)
-"cAE" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/library)
-"cAF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
 "cAH" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
-"cAI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -58018,12 +54708,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"cAL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/library)
 "cAM" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58031,28 +54715,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"cAN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAP" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cAQ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cAR" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cAS" = (
 /obj/structure/closet/wardrobe/curator,
 /turf/open/floor/plasteel/black,
@@ -58081,60 +54743,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
-"cAW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cAZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cBa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cBb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/library)
-"cBc" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cBd" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cBe" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cBf" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cBg" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
-"cBh" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/chapel/asteroid{
-	name = "Monastery Asteroid"
-	})
 "cBi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58222,9 +54830,6 @@
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"cBt" = (
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/dorms)
 "cBu" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -58303,36 +54908,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
-"cBC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBE" = (
-/turf/closed/wall,
-/area/shuttle/escape)
-"cBF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
-"cBG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
-"cBH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBJ" = (
-/turf/closed/wall,
-/area/shuttle/escape)
 "cBK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -58360,38 +54935,379 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"cBO" = (
-/obj/effect/spawner/structure/window/shuttle,
+"cMb" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"djw" = (
+/obj/machinery/turnstile{
+	req_access_txt = "71"
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"dPA" = (
+/obj/machinery/camera{
+	c_tag = "Brig Prison Hallway";
+	network = list("SS13","Prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 1";
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "genpopdoor";
+	name = "General Jail Blast Door";
+	pixel_x = 5;
+	pixel_y = 35;
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/prison)
+"eBV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("Prison");
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/security/prison)
+"fsV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"guM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
+/area/security/brig)
+"hbw" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"cBP" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBQ" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBR" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBS" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBT" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBU" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cBV" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
+/area/security/prison)
+"huI" = (
+/obj/machinery/washing_machine,
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/barber,
+/area/security/prison)
+"hCJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"hTh" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/security/prison)
+"img" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/corner,
+/area/security/prison)
+"irk" = (
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 1;
+	name = "Prison Wing APC";
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"iLE" = (
+/obj/machinery/camera{
+	c_tag = "General Jail Access";
+	dir = 4;
+	network = list("SS13","Prison")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"jnw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/security/brig)
+"jtQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/security/prison)
+"jSA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"jVA" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "permacell2";
+	name = "cell blast door"
+	},
+/obj/machinery/door/airlock/glass{
+	id_tag = "permabolt2";
+	name = "General Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/vault,
+/area/security/prison)
+"khb" = (
+/obj/structure/easel,
+/obj/item/canvas/nineteenXnineteen,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"ksi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"kUW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/red/corner,
+/area/security/prison)
+"mjA" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"mYI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/security/brig)
+"nns" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/security/prison)
+"nwi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Processing";
+	req_access_txt = "2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
+/area/security/brig)
+"nCT" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/red/side,
+/area/security/prison)
+"owE" = (
+/turf/open/floor/plasteel/red/corner,
+/area/security/prison)
+"oLb" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/security/prison)
+"oMf" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/security/prison)
+"oNJ" = (
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "72"
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"oQf" = (
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"qad" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/turnstile{
+	req_access_txt = "71"
+	},
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"rBt" = (
+/obj/structure/bed,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell";
+	network = list("SS13","Prison")
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/prison)
+"tjr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tnq" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ttx" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/black,
+/area/security/prison)
+"tuQ" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/darkred/side,
+/area/security/prison)
+"uEi" = (
+/obj/structure/table,
+/obj/machinery/light,
+/turf/open/floor/plasteel/red/side,
+/area/security/brig)
+"vwf" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/darkred/side,
+/area/security/prison)
+"vAz" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/red/side,
+/area/security/prison)
+"xDI" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/space)
+"xHQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "genpopdoor";
+	name = "Genpop Blast Door"
+	},
+/turf/open/floor/plasteel/vault,
+/area/security/prison)
 
 (1,1,1) = {"
 aaa
@@ -71927,9 +68843,9 @@ bOw
 cfN
 crV
 cfN
-csu
-csJ
-ctf
+cbG
+cef
+ceB
 cfN
 cfN
 cfN
@@ -72184,9 +69100,9 @@ bUC
 bOw
 chT
 cfN
-csu
-csK
-ctf
+cbG
+cee
+ceB
 cfN
 cfN
 cfN
@@ -72441,14 +69357,14 @@ bOw
 bOw
 bOw
 ccu
-csu
-csJ
-ctf
+cbG
+cef
+ceB
 cfN
 cfN
 cfN
 bWV
-crW
+cdr
 cuv
 bXJ
 ceP
@@ -72698,9 +69614,9 @@ bOw
 bOw
 bUC
 bOw
-csu
+cbG
 csM
-ctf
+ceB
 cfN
 cfN
 cfN
@@ -72955,9 +69871,9 @@ bOw
 bOw
 bOw
 bOw
-csu
-csK
-ctf
+cbG
+cee
+ceB
 cfN
 cfN
 cfN
@@ -73212,9 +70128,9 @@ bOw
 bSm
 bOw
 bUC
-csu
-csJ
-ctf
+cbG
+cef
+ceB
 cfN
 cfN
 cfN
@@ -73472,17 +70388,17 @@ bWV
 cdq
 ceg
 chJ
-ctw
-ctw
-ctw
-ctw
-ctw
+cfm
+cfm
+cfm
+cfm
+cfm
 chF
-ctw
+cfm
 cuU
-ctw
-ctw
-ctw
+cfm
+cfm
+cfm
 cjH
 chF
 cuQ
@@ -73726,18 +70642,18 @@ bWV
 bWV
 bXJ
 bYz
-crW
+cdr
 csN
 ctg
 ctx
 ctK
-ctY
+ciD
 cfD
 chf
 cuz
-ctY
+ciD
 cuV
-ctY
+ciD
 cfD
 chf
 cfD
@@ -74243,17 +71159,17 @@ bWV
 bWV
 cei
 bWV
-ctw
+cfm
 ceJ
 cfn
 bWV
-cuc
-cuc
+cgG
+cgG
 bWV
 cuX
 bWV
-cuc
-cuc
+cgG
+cgG
 bWV
 cfn
 ciR
@@ -74495,24 +71411,24 @@ crj
 bXJ
 bXJ
 crK
-crW
+cdr
 cdw
 csv
 csN
 bWV
-ctw
+cfm
 cfF
-ctZ
-cuc
+cgi
+cgG
 chi
 cid
 cuM
 chj
 cvb
-cvf
+ciT
 cvh
-cuc
-ctZ
+cgG
+cgi
 cvF
 cwa
 cwo
@@ -74757,18 +71673,18 @@ cbP
 cdu
 csQ
 ceK
-ctw
+cfm
 cfG
 cfn
-cuc
+cgG
 cid
 cuA
 cib
 cgH
 cgH
-cuN
+ciS
 cid
-cuc
+cgG
 cfn
 cvH
 cwc
@@ -75014,16 +71930,16 @@ cbM
 ccH
 csQ
 ceL
-ctw
+cfm
 ctM
-ctZ
+cgi
 bWV
 cun
 cuB
 cic
 cgH
 chG
-cvf
+ciT
 cjo
 bWV
 cvw
@@ -75274,15 +72190,15 @@ cdw
 cej
 ceM
 cfo
-cuc
+cgG
 cgk
 cuA
-cuN
+ciS
 chk
 cgH
 cgH
 cvi
-cuc
+cgG
 cfn
 ciR
 cwa
@@ -75531,15 +72447,15 @@ cdx
 cek
 ceN
 cfn
-cuc
+cgG
 cuo
-cuq
+ciV
 cgI
 chl
 cib
 cvg
 cid
-cuc
+cgG
 cfn
 ciR
 cwe
@@ -75785,9 +72701,9 @@ cbP
 cdu
 ceP
 cth
-ctw
+cfm
 ctN
-ctZ
+cgi
 bWV
 cup
 cuE
@@ -75797,7 +72713,7 @@ cgH
 cgj
 cvj
 bWV
-ctZ
+cgi
 cvJ
 cwe
 cjP
@@ -76042,18 +72958,18 @@ cbM
 ccH
 ceP
 ceK
-ctw
+cfm
 cfG
 cfn
-cuc
-cuq
+cgG
+ciV
 cgH
 cgH
 cgH
 cic
-cuq
+ciV
 cjq
-cuc
+cgG
 cfn
 ckE
 ckT
@@ -76299,10 +73215,10 @@ cdx
 cgn
 csS
 bWV
-ctw
+cfm
 ctO
-ctZ
-cuc
+cgi
+cgG
 cgm
 cuE
 cuO
@@ -76310,7 +73226,7 @@ cgH
 ciE
 ciW
 cjr
-cuc
+cgG
 cvw
 cvK
 cwg
@@ -76556,17 +73472,17 @@ csk
 bWV
 cbR
 bWV
-ctw
+cfm
 ceP
 cfn
 bWV
-cuc
-cuc
+cgG
+cgG
 bWV
 cuY
 bWV
-cuc
-cuc
+cgG
+cgG
 bWV
 cfn
 ceP
@@ -77084,7 +74000,7 @@ cvk
 cdx
 cvc
 cvM
-ctw
+cfm
 cwe
 cko
 ckH
@@ -77327,21 +74243,21 @@ bQg
 cbR
 bXJ
 cdB
-ctw
-ctw
+cfm
+cfm
 cfH
-ctw
-ctw
+cfm
+cfm
 chp
 cuQ
-ctw
-ctw
+cfm
+cfm
 ciF
 cuQ
-ctw
-ctw
-ctw
-ctw
+cfm
+cfm
+cfm
+cfm
 cwe
 ckp
 ckI
@@ -77463,11 +74379,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aed
 adR
+adR
+aht
+aed
+aht
 abI
 abI
 abI
@@ -77587,15 +74503,15 @@ cen
 bWV
 ctQ
 cfI
-ctw
+cfm
 cgL
 chq
 chK
-ctw
+cfm
 cio
 chq
 ciX
-ctw
+cfm
 cfN
 cfN
 cfN
@@ -77721,11 +74637,11 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
-adR
-aaa
-abI
-aaa
+aem
+aem
+aem
 aem
 aem
 aem
@@ -77844,15 +74760,15 @@ bWV
 bWV
 bWV
 cfJ
-ctw
+cfm
 cgM
 chr
 chL
-ctw
+cfm
 cgM
 chr
 chL
-ctw
+cfm
 cfN
 cfN
 cfN
@@ -77976,10 +74892,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 aaa
 aem
 aem
@@ -77993,10 +74906,13 @@ agy
 agy
 agy
 agy
+mjA
+ttx
+nns
 ahB
 ahZ
 aiB
-ajc
+ttx
 agy
 akB
 alq
@@ -78101,15 +75017,15 @@ cdD
 ceo
 bOw
 cfK
-ctw
+cfm
 cgN
 chs
 chM
-ctw
+cfm
 cip
 chs
 ciY
-ctw
+cfm
 cfN
 cfN
 cfN
@@ -78233,10 +75149,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 abI
 aem
 aeo
@@ -78247,13 +75160,16 @@ afC
 aeU
 aeU
 agy
-agI
+rBt
 agW
 agA
+agI
+agb
+tuQ
 ahC
 aia
 aiC
-ajc
+ttx
 agy
 akC
 alr
@@ -78358,15 +75274,15 @@ bQe
 bOw
 bOw
 cfL
-ctw
-ctw
+cfm
+cfm
 cht
-ctw
-ctw
-ctw
+cfm
+cfm
+cfm
 cht
-ctw
-ctw
+cfm
+cfm
 cfN
 cfN
 cfN
@@ -78490,12 +75406,9 @@ aaa
 aaa
 aaa
 aaa
+xDI
 aaa
-aaa
-aaa
-adR
-aaa
-aen
+hbw
 aep
 aeD
 aeU
@@ -78503,14 +75416,17 @@ afo
 afD
 aga
 aga
-agz
+jVA
 agJ
 agX
+agz
+fsV
+aig
 ahm
 ahD
 aib
 aiD
-ajc
+ttx
 agy
 akD
 als
@@ -78615,15 +75531,15 @@ bOw
 bOw
 bUC
 cfM
-ctw
+cfm
 cgO
 chu
 chN
-ctw
+cfm
 ciq
 chu
 ciZ
-ctw
+cfm
 cfN
 cfN
 cfN
@@ -78747,10 +75663,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 abI
 aem
 aeq
@@ -78764,6 +75677,9 @@ agy
 agK
 agY
 agy
+eBV
+tjr
+owE
 ahE
 aic
 aiE
@@ -78872,15 +75788,15 @@ bNs
 bNs
 bNs
 bNs
-ctw
-ctw
-ctw
-ctw
-ctw
-ctw
-ctw
-ctw
-ctw
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
+cfm
 cfN
 cfN
 cfN
@@ -79004,12 +75920,9 @@ aaa
 aaa
 aaa
 aaa
+xDI
 aaa
-aaa
-aaa
-adR
-aaa
-aen
+hbw
 aer
 aeF
 aeV
@@ -79021,6 +75934,9 @@ agA
 agA
 agA
 ahn
+dPA
+aig
+vAz
 ahF
 aic
 aiF
@@ -79038,7 +75954,7 @@ aom
 ark
 asu
 atv
-aux
+jnw
 avs
 awI
 axF
@@ -79261,20 +76177,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 abI
 aem
-aes
+khb
 aeG
 aeU
 afo
 afG
 aeU
 aeU
-agy
+djw
+iLE
+oQf
+qad
 agL
 agZ
 aho
@@ -79518,12 +76434,9 @@ aaa
 aaa
 aaa
 aaa
+xDI
 aaa
-aaa
-aaa
-adR
-aaa
-aen
+hbw
 aet
 aeH
 aeH
@@ -79531,13 +76444,16 @@ aeH
 afH
 aeH
 aeH
+xHQ
+ksi
+hCJ
 agB
-agM
-aha
-ahp
 ahH
-aie
 aiH
+ahp
+jtQ
+aie
+kUW
 ajf
 ajL
 akH
@@ -79549,10 +76465,10 @@ aoo
 aoo
 aoo
 aqn
-arl
-asw
+aon
+asC
 atx
-auz
+aon
 avu
 awJ
 axG
@@ -79775,10 +76691,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 abI
 aem
 aeu
@@ -79788,13 +76701,16 @@ aeU
 afI
 aeU
 aeU
-agy
-agN
-agY
-agy
+oNJ
+cMb
+jSA
+oNJ
 ahI
+aig
+img
+oMf
 aif
-aiB
+nCT
 agy
 ajM
 akI
@@ -79809,8 +76725,8 @@ aqo
 alv
 asx
 aty
-ajM
-ajM
+aon
+uEi
 atB
 axH
 ayI
@@ -80032,10 +76948,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-adR
+xDI
 aaa
 aem
 aem
@@ -80049,8 +76962,11 @@ agy
 agy
 agy
 agy
+irk
+aeU
+vwf
 ahJ
-aig
+jSA
 aiJ
 agy
 ajN
@@ -80064,9 +76980,9 @@ aoR
 apJ
 aqp
 aon
-asy
-atz
-aux
+asC
+nwi
+aon
 avv
 awK
 axG
@@ -80291,13 +77207,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-adR
-aaa
 abI
 aaa
 aem
-aeX
+huI
 afs
 aem
 agd
@@ -80306,6 +77219,9 @@ agC
 agO
 ahb
 agy
+oLb
+ttx
+hTh
 ahK
 aih
 aiK
@@ -80323,7 +77239,7 @@ aqq
 aon
 asv
 atA
-auA
+tnq
 avw
 awJ
 axG
@@ -80547,12 +77463,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aed
 adR
-abI
+aht
+aem
+aem
+aem
 aem
 aem
 aem
@@ -80579,8 +77495,8 @@ apK
 aqr
 arl
 asw
-atx
-auz
+guM
+mYI
 avx
 awJ
 axG
@@ -80835,7 +77751,7 @@ aoU
 apL
 aqs
 aon
-asz
+asC
 atB
 ajM
 ajM
@@ -82616,7 +79532,7 @@ aaa
 aby
 aaa
 agQ
-cnK
+ahd
 ahq
 ahq
 ahN
@@ -82873,11 +79789,11 @@ aaa
 aby
 aaa
 agQ
-cnK
+ahd
 ahq
 cnT
 ahq
-cnK
+ahd
 agP
 ajm
 ajW
@@ -83130,11 +80046,11 @@ afJ
 aby
 aaa
 agQ
-cnK
+ahd
 ahq
 ahq
 ahq
-cnK
+ahd
 agP
 ajn
 ajW
@@ -83391,7 +80307,7 @@ cnN
 ahq
 cnT
 ahq
-cnK
+ahd
 agP
 ajo
 ajX
@@ -83644,7 +80560,7 @@ aaa
 aby
 aaa
 agQ
-cnK
+ahd
 ahq
 ahq
 ahq
@@ -88563,7 +85479,7 @@ aHf
 aHX
 aIW
 coz
-coE
+aKV
 abI
 aKT
 coG
@@ -88820,7 +85736,7 @@ aHf
 aHX
 aIW
 coz
-coE
+aKV
 abI
 aKT
 coH
@@ -89077,7 +85993,7 @@ aHf
 aHY
 aIX
 coB
-coE
+aKV
 abI
 aKT
 coH
@@ -89334,7 +86250,7 @@ aHf
 aHX
 aIW
 coz
-coE
+aKV
 abI
 aKT
 coJ
@@ -89591,7 +86507,7 @@ aHf
 aHX
 aIY
 coz
-coE
+aKV
 abI
 aKT
 coJ
@@ -90120,8 +87036,8 @@ bah
 aYe
 aZb
 bag
-cpp
-cpp
+bbr
+bbr
 bdv
 bez
 cpC
@@ -90631,7 +87547,7 @@ aPE
 aVh
 bah
 bah
-cpf
+aYg
 cph
 bag
 bbp
@@ -90888,7 +87804,7 @@ aPE
 aVi
 bah
 aXh
-cpf
+aYg
 aZd
 beB
 bbq
@@ -91145,11 +88061,11 @@ aPE
 cpb
 bah
 bah
-cpf
+aYg
 cpi
 bag
-cpp
-cpp
+bbr
+bbr
 bah
 bag
 bfs
@@ -95471,7 +92387,7 @@ cBk
 aju
 cBo
 alQ
-cBt
+alb
 cBw
 aiS
 aiS
@@ -95728,8 +92644,8 @@ ajv
 aju
 ajt
 alQ
-cBt
-cBt
+alb
+alb
 aiS
 anY
 apt
@@ -95986,7 +92902,7 @@ akh
 alc
 alR
 amF
-cBt
+alb
 anm
 ajv
 ajv
@@ -96243,7 +93159,7 @@ cBm
 cBp
 alS
 amG
-cBt
+alb
 aiS
 aiS
 aiS


### PR DESCRIPTION
Adds genpop, genpop lockers, and a processing room to pubby station.

:cl: 
add: Adds processing to pubby station
tweak: Changes permabrig to genpop, along with genpop lockers added.
del: Cells deleted to make way for processing.
/:cl:

Pubby station tends to be unused, and I believe one of the reasons being the lack of genpop, which this adds to, along with a processing.

**NOTE:** This still needs testing for any missed things/access to stuff, and pictures will be eventually added.
