### PR TITLE
Text filtering

### DIFF
--- a/code/__HELPERS/text_filter.dm
+++ b/code/__HELPERS/text_filter.dm
@@ -1,0 +1,11 @@
+GLOBAL_DATUM_INIT(text_filter_datum, /datum/text_filter, new)
+
+/datum/text_filter
+	//used for some text operations that need to hold a bunch of regexes or whatever in memory
+	//probably not the best way to do it, but globals are bad
+	var/static/regex/reeegex = new("(^|\\W)\[Rr]\[Ee]+\[Ee]($|\\W)")
+
+/datum/text_filter/proc/ree_check(message)
+	if(reeegex.Find(message))
+		return TRUE
+	return FALSE

--- a/code/__HELPERS/text_filter.dm
+++ b/code/__HELPERS/text_filter.dm
@@ -3,9 +3,15 @@ GLOBAL_DATUM_INIT(text_filter_datum, /datum/text_filter, new)
 /datum/text_filter
 	//used for some text operations that need to hold a bunch of regexes or whatever in memory
 	//probably not the best way to do it, but globals are bad
-	var/static/regex/reeegex = new("(^|\\W)\[Rr]\[Ee]+\[Ee]($|\\W)")
+	var/static/regex/reeegex = new(@"\b[Rr]+[Ee]{2,}\b")
+	var/static/regex/yeetgex = new(@"\b[Yy]+[Ee]{2,}[Tt]+([Ee][Dd])?([Ii][Nn][Gg])?\b")
 
 /datum/text_filter/proc/ree_check(message)
 	if(reeegex.Find(message))
+		return TRUE
+	return FALSE
+
+/datum/text_filter/proc/yeet_check(message)
+	if(yeetgex.Find(message))
 		return TRUE
 	return FALSE

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -21,5 +21,6 @@ GLOBAL_LIST_INIT(posibrain_names, world.file2list("strings/names/posibrain.txt")
 GLOBAL_LIST_INIT(verbs, world.file2list("strings/names/verbs.txt"))
 GLOBAL_LIST_INIT(adjectives, world.file2list("strings/names/adjectives.txt"))
 GLOBAL_LIST_INIT(dream_strings, world.file2list("strings/dreamstrings.txt"))
+GLOBAL_LIST_INIT(retard_lines, world.file2list("strings/retard_lines.txt"))
 //loaded on startup because of "
 //would include in rsc if ' was used

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -140,6 +140,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!can_speak_vocal(message))
 		to_chat(src, "<span class='warning'>You find yourself unable to speak!</span>")
 		return
+		
+	if(check_retard_speech(message))
+		var/reeee = pick(GLOB.retard_lines)
+		to_chat(src, "<span class='warning'>[reeee]</span>")
+		adjustBrainLoss(20, 150)//20 damage, max 150, so 75%
+		return
 
 	var/message_range = 7
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -144,7 +144,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(check_retard_speech(message))
 		var/reeee = pick(GLOB.retard_lines)
 		to_chat(src, "<span class='warning'>[reeee]</span>")
-		adjustBrainLoss(20, 150)//20 damage, max 150, so 75%
 		return
 
 	var/message_range = 7

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -501,3 +501,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		if("X*")//xeno blood; not actually used in many spots
 			. = "#88aa00"
 		//add more stuff to the switch if you have more blood colors for different types
+
+/proc/check_retard_speech(message = "")
+	if(GLOB.text_filter_datum.ree_check(message))
+		return TRUE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -505,3 +505,5 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 /proc/check_retard_speech(message = "")
 	if(GLOB.text_filter_datum.ree_check(message))
 		return TRUE
+	if(GLOB.text_filter_datum.yeet_check(message))
+		return TRUE

--- a/strings/retard_lines.txt
+++ b/strings/retard_lines.txt
@@ -19,5 +19,5 @@ Your vocal cords have to have it really bad with you, don't they?
 Your butt must feel jealous of your mouth from all the shit that comes out of it.
 You feel like punching yourself in the face would be justified right now.
 Your head aches as images of screaming frogs fill your vision for a split-second.
-All you can manage is a strangled croak before you sstop yourself from spouting that garbage.
+All you can manage is a strangled croak before you stop yourself from spouting that garbage.
 It would appear the source of the problem is located between the chair and the keyboard.

--- a/strings/retard_lines.txt
+++ b/strings/retard_lines.txt
@@ -1,0 +1,6 @@
+You find yourself a few fries short of a happy meal.
+You realise you've forgotten to wear your helmet today.
+Now you know why you're not allowed to sharpen the crayons.
+You realize you're absolutely heckin' retarded.
+You reconsider the garbage that was about to come out of your mouth.
+Simply thinking about trying to say that made you just a little bit dumber.

--- a/strings/retard_lines.txt
+++ b/strings/retard_lines.txt
@@ -1,6 +1,16 @@
 You find yourself a few fries short of a happy meal.
 You realise you've forgotten to wear your helmet today.
 Now you know why you're not allowed to sharpen the crayons.
-You realize you're absolutely heckin' retarded.
+You realize you're absolutely fucking retarded.
 You reconsider the garbage that was about to come out of your mouth.
 Simply thinking about trying to say that made you just a little bit dumber.
+You re-evaluate your life choices.
+How many times were you dropped as a child, exactly?
+You'll need a breather after coming up with that thing.
+You feel like a screw is loose... but you don't have any screws, do you?
+You feel as if you're a few sandwiches short of a picnic.
+You feel as though you're a few cards short of a full deck.
+You feel like you're a few beers short of a six-pack.
+You feel like you're a few metaphors short of a mental breakdown.
+You feel like your IQ just dipped below room temperature.
+You feel dumber than a box of Donk pockets, and boy are those dumb.

--- a/strings/retard_lines.txt
+++ b/strings/retard_lines.txt
@@ -14,3 +14,10 @@ You feel like you're a few beers short of a six-pack.
 You feel like you're a few metaphors short of a mental breakdown.
 You feel like your IQ just dipped below room temperature.
 You feel dumber than a box of Donk pockets, and boy are those dumb.
+You can't quite believe it, but it seems that your words have managed to be emptier than your head.
+Your vocal cords have to have it really bad with you, don't they?
+Your butt must feel jealous of your mouth from all the shit that comes out of it.
+You feel like punching yourself in the face would be justified right now.
+Your head aches as images of screaming frogs fill your vision for a split-second.
+All you can manage is a strangled croak before you sstop yourself from spouting that garbage.
+It would appear the source of the problem is located between the chair and the keyboard.

--- a/strings/retard_lines.txt
+++ b/strings/retard_lines.txt
@@ -1,7 +1,7 @@
 You find yourself a few fries short of a happy meal.
-You realise you've forgotten to wear your helmet today.
+You realize you've forgotten to wear your helmet today.
 Now you know why you're not allowed to sharpen the crayons.
-You realize you're absolutely fucking retarded.
+That was absolutely fucking retarded.
 You reconsider the garbage that was about to come out of your mouth.
 Simply thinking about trying to say that made you just a little bit dumber.
 You re-evaluate your life choices.
@@ -15,8 +15,7 @@ You feel like you're a few metaphors short of a mental breakdown.
 You feel like your IQ just dipped below room temperature.
 You feel dumber than a box of Donk pockets, and boy are those dumb.
 You can't quite believe it, but it seems that your words have managed to be emptier than your head.
-Your vocal cords have to have it really bad with you, don't they?
-Your butt must feel jealous of your mouth from all the shit that comes out of it.
+Those vocal cords have to have it really bad with you, don't they?
 You feel like punching yourself in the face would be justified right now.
 Your head aches as images of screaming frogs fill your vision for a split-second.
 All you can manage is a strangled croak before you stop yourself from spouting that garbage.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -95,6 +95,7 @@
 #include "code\__HELPERS\radio.dm"
 #include "code\__HELPERS\sanitize_values.dm"
 #include "code\__HELPERS\text.dm"
+#include "code\__HELPERS\text_filter.dm"
 #include "code\__HELPERS\time.dm"
 #include "code\__HELPERS\type2type.dm"
 #include "code\__HELPERS\unique_ids.dm"


### PR DESCRIPTION
:cl: Flatty, Ralta and FeiH
add: REEing or Yeeting now gives you a witty line instead of letting you spout that garbage.
/:cl:

I tested this on this file: https://raw.githubusercontent.com/dwyl/english-words/master/words.txt which is over 466 thousand words from the English language. It only triggered on one: `Ree`. Not sure what the word means in English, but I'm afraid to check.

I also added a yeet regex now. It will block a `yet` with more than one `e`, so watch yourself.

It doesn't deal brain damage anymore. Just stops you from saying the thing.

I need help writing more witty lines.