### PR TITLE
Fix various syntactic problems

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -458,7 +458,7 @@
 #error Remie said that lummox was adding a way to get a lists
 #error contents via list.values, if that is true remove this
 #error otherwise, update the version and bug lummox
-#elseif
+#endif
 //Flattens a keyed list into a list of it's contents
 /proc/flatten_list(list/key_list)
 	if(!islist(key_list))

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -814,9 +814,9 @@ The _flatIcons list is a cache for generated icon files.
 	var/icon/add // Icon of overlay being added
 
 		// Current dimensions of flattened icon
-	var/{flatX1=1;flatX2=flat.Width();flatY1=1;flatY2=flat.Height()}
+	var/flatX1=1, flatX2=flat.Width(), flatY1=1, flatY2=flat.Height()
 		// Dimensions of overlay being added
-	var/{addX1;addX2;addY1;addY2}
+	var/addX1, addX2, addY1, addY2
 
 	for(var/V in layers)
 		var/image/I = V

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -57,7 +57,6 @@ GLOBAL_LIST_EMPTY(rad_collectors)
 		else
 			to_chat(user, "<span class='warning'>The controls are locked!</span>")
 			return
-..()
 
 /obj/machinery/power/rad_collector/can_be_unfasten_wrench(mob/user, silent)
 	if(loaded_tank)


### PR DESCRIPTION
Code cleanup necessary for the map renderer to work.

Fixes SpaceManiac/SpacemanDMM#17.

Precedent:
vgstation-coders/vgstation13#18604
Baystation12/Baystation12#21616
VOREStation/VOREStation#3714
ParadiseSS13/Paradise#8742
yogstation13/yogstation#3137
tgstation/tgstation#32284