### PR TITLE
HoP and Cap get those cute mini eguns instead of the big-ass ones

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -29,7 +29,7 @@
 	new /obj/item/clothing/gloves/color/captain(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
 	new /obj/item/storage/belt/sabre(src)
-	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/gun/energy/e_gun/mini(src)
 	new /obj/item/door_remote/captain(src)
 
 /obj/structure/closet/secure_closet/hop
@@ -52,7 +52,7 @@
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/gun/energy/e_gun/mini(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/door_remote/civillian(src)
 


### PR DESCRIPTION
It was talked about earlier at some point. I like the idea. Discuss.

:cl: Flatty
tweak: The Head of Personnel and Captain will start with smaller e-guns for more portability, but less firepower.
/:cl:

To clarify:
* 40% less ammo
* in-built flashlight
* fits in pockets or up your ass
* the same as a regular e-gun in every other regard

