### PR TITLE
Updated Heat-lamp syndrome to be more in-depth

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -244,17 +244,30 @@
 /datum/disease/transformation/lizard
 	name = "Heat-Lamp Syndrome"
 	max_stages = 5
-	cure_text = "Unknown"
-	cures = list("adminordrazine")
+	cure_text = "Milk"
+	cures = list("milk")
 	agent = "lizard tears"
 	desc = "This disease turns its victim into a small lizard."
 	viable_mobtypes = list(/mob/living/carbon/human)
 	severity = HARMFUL
-	stage_prob = 10
 	visibility_flags = 0
 	stage1 = list("You feel dry.")
 	stage2 = list("You feel like following the janitor.")
-	stage3 = list("Your skin feels a bit... scaly.")
-	stage4 = list("It's too cold in here.")
-	stage5 = list("You begin to feel small.")
+	stage3 = list("<span class='danger'>Your skin feels a bit... scaly.</span>")
+	stage4 = list("<span class='danger'>A juicy roach sounds delicious right about now.</span>")
+	stage5 = list("<span class='danger'>It's too cold in here!</span>", "<span class='danger'>You feel small...</span>")
 	new_form = /mob/living/simple_animal/hostile/lizard
+	infectable_hosts = list(SPECIES_ORGANIC)
+	var/datum/species/unathi/unathi = new /datum/species/unathi()
+
+/datum/disease/transformation/lizard/stage_act()
+	..()
+	switch(stage)
+		if(3)
+			if (prob(10))
+				affected_mob.say(pick("Hiss!"))
+		if(4)
+			affected_mob.set_species(unathi)
+		if(5)
+			if (prob(20))
+				affected_mob.say(pick("Hisss!", "Ssskree!", "HISSS!!"))


### PR DESCRIPTION
:cl: Battletrap360
tweak: Tweaked Heat-Lamp Syndrome by increasing the time between stages, adding an easily obtainable cure (milk), changing flavor text a bit, and adding a Unathi transformation to reflect the symptoms.
/:cl:

[why]:
I did this to improve my knowledge of SS13 code, as well as provide a fun disease for the admins to play around with if they so please.
