### PR TITLE
No More Revenant SSD Soul Absorbtion

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -14,7 +14,10 @@
 	if(draining)
 		to_chat(src, "<span class='revenwarning'>You are already siphoning the essence of a soul!</span>")
 		return
-	if(!target.stat && !target.isLivingSSD())
+	if(target.isLivingSSD())
+		to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is beyond your reach.</span>")
+		return
+	if(!target.stat)
 		to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is too strong to harvest.</span>")
 		if(prob(10))
 			to_chat(target, "You feel as if you are being watched.")


### PR DESCRIPTION
:cl: AndrewMontagne
tweak: Revenants can no longer absorb the souls of alive SSD players.
/:cl:
