### PR TITLE
Removes the "die a glorious death" objective.

### DIFF
--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -157,9 +157,13 @@
 			break
 
 	if(martyr_compatibility && martyr_chance)
-		var/datum/objective/martyr/martyr_objective = new
-		martyr_objective.owner = owner
-		add_objective(martyr_objective)
+		//Nothing happens.
+		//This used to be the martyr objective to end your life,
+		//but since that doesn't give you a license to grief and
+		//some people might not even want to die,
+		//we're just leaving this empty.
+		//That's ltierally the best way to handle this.
+		//Feels weird, doesn't it?
 		return
 
 	else

--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -157,7 +157,7 @@
 			break
 
 	if(martyr_compatibility && martyr_chance)
-		//Nothing happens.
+		forge_single_objective(TRUE)
 		//This used to be the martyr objective to end your life,
 		//but since that doesn't give you a license to grief and
 		//some people might not even want to die,
@@ -190,9 +190,9 @@
 	add_objective(survive_objective)
 /datum/antagonist/traitor/proc/forge_single_objective()
 	return 0
-/datum/antagonist/traitor/human/forge_single_objective() //Returns how many objectives are added
+/datum/antagonist/traitor/human/forge_single_objective(martyr_compatible = FALSE) //Returns how many objectives are added
 	.=1
-	if(prob(50))
+	if(prob(50) || martyr_compatible)
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new


### PR DESCRIPTION
A reopen of a part of #820.

This PR removes the `die a glorious death` objective from regular traitors.

This PR doesn't remove the interactions possible right now. You will now have one free objective slot instead of that old one, which means you yourself can choose to get yourself killed or escape on the shuttle. The "free slot" thingy has the same chance and prerequisites for being picked as the old objective.

Here's my reasoning:
* The objective makes it seem like you are allowed to do anything "glorious" (i.e. acts of terrorism) to complete it. That is wrong, and doing so is a breach of rules that might lead to a ban, as it already has, multiple times.
* Some people might not want to die and forcing them to choose between greentext and having their character survive the round is odd.
* People who want to powergame the objective to win will just silently kill themselves in maint, which is really uneventful.
* The only reasonable way to accomplish this objective in a manner that is interesting to you and other players is to specifically let Security kill you during a chase, which is so rare that we might as well let people choose whether to do it themselves.

:cl: Flatty
tweak: Removes the "Die a glorious death" objective from traitors
/:cl: