### PR TITLE
No More Green Slimes

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -73,7 +73,7 @@
 
 	var/static/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 	"blue", "dark blue", "dark purple", "yellow", "silver", "pink", "red",
-	"gold", "green", "adamantine", "oil", "light pink", "bluespace",
+	"gold", /*"green",*/ "adamantine", "oil", "light pink", "bluespace",
 	"cerulean", "sepia", "black", "pyrite")
 
 /mob/living/simple_animal/slime/Initialize(mapload, new_colour="grey", new_is_adult=FALSE)

--- a/code/modules/mob/living/simple_animal/slime/subtypes.dm
+++ b/code/modules/mob/living/simple_animal/slime/subtypes.dm
@@ -11,8 +11,9 @@
 		if("purple")
 			slime_mutation[1] = "dark purple"
 			slime_mutation[2] = "dark blue"
-			slime_mutation[3] = "green"
-			slime_mutation[4] = "green"
+			// Stops the mutation toxin memery in its tracks right here.
+			//slime_mutation[3] = "green"
+			//slime_mutation[4] = "green"
 		if("metal")
 			slime_mutation[1] = "silver"
 			slime_mutation[2] = "yellow"


### PR DESCRIPTION
Removes green slimes from the random mutation chance list. This is why we can't have nice things.

:cl: AndrewMontagne
tweak: Removed Green Slimes from the mutation chance table
/:cl: