### PR TITLE
General animation fancification

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -511,40 +511,6 @@
 	sleep(1)
 	animate(I, alpha = 0, time = 1)
 
-/obj/item/proc/do_pickup_animation(turf/target)
-	set waitfor = FALSE
-	var/image/I = image(icon = src, loc = loc, layer = layer + 0.1)
-	I.plane = GAME_PLANE
-	I.transform *= 0.75
-	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	var/direction = get_dir(src, target)
-	var/to_x = 0
-	var/to_y = 0
-	if(direction & NORTH)
-		to_y = 32
-	else if(direction & SOUTH)
-		to_y = -32
-
-	if(direction & EAST)
-		to_x = 32
-	else if(direction & WEST)
-		to_x = -32
-
-	if(!direction)
-		to_y = 16
-
-	flick_overlay(I, GLOB.clients, 6)
-	var/matrix/M = new
-	M.Turn(pick(-30, 30))
-
-	animate(I, transform = M, time = 1)
-	sleep(1)
-	animate(I, transform = matrix(), time = 1)
-	sleep(1)
-	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, easing = CUBIC_EASING)
-	sleep(1)
-	animate(I, alpha = 0, time = 1)
-
 /atom/movable/vv_get_dropdown()
 	. = ..()
 	. -= "Jump to"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -473,7 +473,7 @@
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
 	else if(used_item)
-		I = image(used_item.icon, A, used_item.icon_state, A.layer + 0.1)
+		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
 
 		// Scale the icon.
 		I.transform *= 0.75

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -468,6 +468,7 @@
 	animate(pixel_x = initial(pixel_x), pixel_y = final_pixel_y, time = 2, easing = CUBIC_EASING)
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
+	set waitfor = FALSE
 	var/image/I
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
@@ -498,9 +499,17 @@
 		return
 
 	flick_overlay(I, GLOB.clients, 5) // 5 ticks/half a second
-
+	var/matrix/M = new
+	M.Scale(0.9)
+	M.Turn(pick(-20, 20))
 	// And animate the attack!
-	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3, easing = CUBIC_EASING)
+	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 2, easing = CUBIC_EASING)
+	sleep(2)
+	animate(I, transform = M, time = 1) // apply the fancy matrix
+	sleep(1)
+	animate(I, transform = matrix(), time = 1) // back to a default matrix
+	sleep(1)
+	animate(I, alpha = 0, time = 1)
 
 /atom/movable/vv_get_dropdown()
 	. = ..()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -474,6 +474,7 @@
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
 	else if(used_item)
 		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
+		I.plane = GAME_PLANE
 
 		// Scale the icon.
 		I.transform *= 0.75

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -501,7 +501,6 @@
 
 	flick_overlay(I, GLOB.clients, 5) // 5 ticks/half a second
 	var/matrix/M = new
-	M.Scale(0.9)
 	M.Turn(pick(-20, 20))
 	// And animate the attack!
 	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 2, easing = CUBIC_EASING)
@@ -509,6 +508,40 @@
 	animate(I, transform = M, time = 1) // apply the fancy matrix
 	sleep(1)
 	animate(I, transform = matrix(), time = 1) // back to a default matrix
+	sleep(1)
+	animate(I, alpha = 0, time = 1)
+
+/obj/item/proc/do_pickup_animation(turf/target)
+	set waitfor = FALSE
+	var/image/I = image(icon = src, loc = loc, layer = layer + 0.1)
+	I.plane = GAME_PLANE
+	I.transform *= 0.75
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	var/direction = get_dir(src, target)
+	var/to_x = 0
+	var/to_y = 0
+	if(direction & NORTH)
+		to_y = 32
+	else if(direction & SOUTH)
+		to_y = -32
+
+	if(direction & EAST)
+		to_x = 32
+	else if(direction & WEST)
+		to_x = -32
+
+	if(!direction)
+		to_y = 16
+
+	flick_overlay(I, GLOB.clients, 6)
+	var/matrix/M = new
+	M.Turn(pick(-30, 30))
+
+	animate(I, transform = M, time = 1)
+	sleep(1)
+	animate(I, transform = matrix(), time = 1)
+	sleep(1)
+	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, easing = CUBIC_EASING)
 	sleep(1)
 	animate(I, alpha = 0, time = 1)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -264,7 +264,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(istype(loc, /obj/item/storage))
 		//If the item is in a storage item, take it out
 		var/obj/item/storage/S = loc
-		S.remove_from_storage(src, user.loc)
+		S.remove_from_storage(src, S.loc)
 
 	if(throwing)
 		throwing.finalize(FALSE)
@@ -286,7 +286,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	if(istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
-		S.remove_from_storage(src, user.loc)
+		S.remove_from_storage(src, S.loc)
 
 	if(throwing)
 		throwing.finalize(FALSE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -698,3 +698,31 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/MouseExited()
 	deltimer(tip_timer)//delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
+
+/obj/item/proc/do_pickup_animation(turf/target)
+	set waitfor = FALSE
+	var/turf/T = get_turf(src)
+	var/image/I = image(icon = src, loc = loc, layer = layer + 0.1)
+	I.plane = GAME_PLANE
+	I.transform *= 0.75
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	flick_overlay(I, GLOB.clients, 6)
+	var/matrix/M = new
+	M.Turn(pick(-30, 30))
+
+	animate(I, transform = M, time = 1)
+	sleep(1)
+	animate(I, transform = matrix(), time = 1)
+	sleep(1)
+
+	if(QDELETED(target) || QDELETED(src))
+		return
+	var/to_x = (target.x - T.x) * 32
+	var/to_y = (target.y - T.y) * 32
+
+	if(!to_x && !to_y)
+		to_y = 20
+
+	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, easing = CUBIC_EASING)
+	sleep(1)
+	animate(I, alpha = 0, time = 1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -269,13 +269,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!user.dropItemToGround(src))
+		if(!user.temporarilyRemoveItemFromInventory(src))// changed this line from dropItemToGround() to this; not sure why it works, but it works ~Flatty
 			return
 
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src))
-		dropped(user)
+		src.forceMove(user.loc)// this line had dropped() on it and I am also not sure why this works but it does ~Flatty
 
 
 /obj/item/attack_paw(mob/user)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -335,14 +335,14 @@
 /obj/item/storage/bag/tray/proc/rebuild_overlays()
 	cut_overlays()
 	for(var/obj/item/I in contents)
-		add_overlay(mutable_appearance(I.icon, I.icon_state))
+		add_overlay(new /mutable_appearance(I))
 
 /obj/item/storage/bag/tray/remove_from_storage(obj/item/W as obj, atom/new_location)
 	..()
 	rebuild_overlays()
 
 /obj/item/storage/bag/tray/handle_item_insertion(obj/item/I, prevent_warning = 0)
-	add_overlay(mutable_appearance(I.icon, I.icon_state))
+	add_overlay(new /mutable_appearance(I))
 	. = ..()
 
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -165,6 +165,8 @@
 
 /mob/proc/put_in_hand(obj/item/I, hand_index)
 	if(can_put_in_hand(I, hand_index))
+		if(isturf(I.loc))
+			I.do_pickup_animation(src)
 		I.forceMove(src)
 		held_items[hand_index] = I
 		I.layer = ABOVE_HUD_LAYER

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -165,7 +165,11 @@
 
 /mob/proc/put_in_hand(obj/item/I, hand_index)
 	if(can_put_in_hand(I, hand_index))
-		if(isturf(I.loc))
+		if(m_intent == MOVE_INTENT_WALK)
+			to_chat(src, "<span class='notice'>You start [pick("inconspicuously", "slowly", "carefully", "silently")] picking up [I]. (Walk mode)</span>")
+			if(!do_after(src, 2 SECONDS, target = I))
+				return FALSE
+		else if(isturf(I.loc))
 			I.do_pickup_animation(src)
 		I.forceMove(src)
 		held_items[hand_index] = I


### PR DESCRIPTION
![](https://i.imgur.com/HsnkcDr.gif)
![](https://i.imgur.com/krP4YJ9.gif)

:cl: Flatty
tweak: The attack animations will be just a bit prettier now.
feature: There are pickup animations for items now! You can go around them by turning Walk mode on.
/:cl:

I made a really weird change to `code/game/objects/items.dm`, which, even though fairly logical, has the potential to break shit. I've tested it quite a bit and it seems to work without hiccups, but please read that code carefully and tell me whether it will break everything or not. K thx. That also fixes #897, because why wouldn't it, obviously.

ALSO, I think this might be broken by Purp's big-ass /tg/ port, so I'd like that merged before this PR. :candle:

Also ports some PRs from /tg/ that are related.