### PR TITLE
Makes the med cyborg module candy dispenser less spammy

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -340,12 +340,12 @@
 	name = "lollipop fabricator"
 	desc = "Reward good humans with this. Toggle in-module to switch between dispensing and high velocity ejection modes."
 	icon_state = "lollipop"
-	var/candy = 30
-	var/candymax = 30
-	var/charge_delay = 10
+	var/candy = 15
+	var/candymax = 15
+	var/charge_delay = 40
 	var/charging = 0
 	var/mode = 1
-	var/firedelay = 0
+	var/firedelay = 50
 	var/hitspeed = 2
 	var/hitdamage = 0
 	var/emaggedhitdamage = 3


### PR DESCRIPTION
Makes the mediborg candy dispenser less spammy. It can only hold 15 candy at one time and it takes about 5 - 6 seconds to charge to get one candy. Spamming the dispenser while not having candy also takes some of the borg's power, unintentional, but I think it can be left as a punishment.

Only thing I see is that it nerf the mediborg's damage with it when emagged.


:cl: 
tweak: Mediborg candy dispenser can only hold 15 candy at one time.
tweak: Mediborg candy dispenser takes about 6 seconds to charge up one candy.
/:cl:

