### PR TITLE
Briefcase fix and update

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -15,20 +15,16 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE
 	max_integrity = 150
-	var/folder_path = /obj/item/folder //this is the path of the folder that gets spawned in New()
 
-/obj/item/storage/briefcase/PopulateContents()
-	new /obj/item/pen(src)
-	var/obj/item/folder/folder = new folder_path(src)
-	for(var/i in 1 to 6)
-		new /obj/item/paper(folder)
 
-/obj/item/storage/briefcase/lawyer
-	folder_path = /obj/item/folder/blue
 
-/obj/item/storage/briefcase/lawyer/PopulateContents()
+/obj/item/storage/briefcase/iaa
+
+/obj/item/storage/briefcase/iaa/PopulateContents()
+	new /obj/item/pen/fourcolor(src)
+	new /obj/item/folder/blue(src)
 	new /obj/item/stamp/iaa(src)
-	..()
+
 
 /obj/item/storage/briefcase/sniperbundle
 	name = "briefcase"
@@ -47,7 +43,6 @@
 	max_integrity = 150
 
 /obj/item/storage/briefcase/sniperbundle/PopulateContents()
-	..() // in case you need any paperwork done after your rampage
 	new /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate(src)
 	new /obj/item/clothing/neck/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -284,7 +284,7 @@
 	max_combined_w_class = 21
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/storage/briefcase/PopulateContents()
+/obj/item/storage/briefcase/inflatable/PopulateContents()
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -192,7 +192,7 @@ Internal Affairs Agent
 	suit = /obj/item/clothing/suit/toggle/iaa/black
 	glasses = /obj/item/clothing/glasses/sunglasses
 	shoes = /obj/item/clothing/shoes/laceup
-	l_hand = /obj/item/storage/briefcase
+	l_hand = /obj/item/storage/briefcase/iaa
 	l_pocket = /obj/item/device/laser_pointer
 	r_pocket = /obj/item/device/assembly/flash/handheld
 


### PR DESCRIPTION
Fixes normal briefcases starting with inflatable walls and inflatable doors.
Mapped briefcases start off completely empty.
The IAA starts off with a briefcase with the following: Multi color pen, IAA stamp, and a blue folder.


:cl: 
fix: Fixed normal briefcases starting with inflatable walls and doors.
tweak: IAA starts with a briefcase that has a multicolor pen, a stamp and a blue folder.
tweak: Mapped briefcases start empty.
/:cl:

