### PR TITLE
Preserve supply console contraband/emag value

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -21,9 +21,10 @@
 /obj/machinery/computer/cargo/Initialize(mapload, obj/item/circuitboard/computer/cargo/C)
 	. = ..()
 
-	// Propagate contraband/emag values from the circuit board used to construct the console.
-	contraband = C.contraband
-	emagged = C.emagged
+	if (C)
+		// Propagate contraband/emag values from the circuit board used to construct the console.
+		contraband = C.contraband
+		emagged = C.emagged
 
 	// This also permamently sets this on the circuit board to preserve the values when the console is deconstructed.
 	var/obj/item/circuitboard/computer/cargo/board = circuit

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -18,11 +18,17 @@
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
 
-/obj/machinery/computer/cargo/Initialize()
+/obj/machinery/computer/cargo/Initialize(mapload, obj/item/circuitboard/computer/cargo/C)
 	. = ..()
+
+	// Propagate contraband/emag values from the circuit board used to construct the console.
+	contraband = C.contraband
+	emagged = C.emagged
+
+	// This also permamently sets this on the circuit board to preserve the values when the console is deconstructed.
 	var/obj/item/circuitboard/computer/cargo/board = circuit
-	contraband = board.contraband
-	emagged = board.emagged
+	board.contraband = contraband
+	board.emagged = emagged
 
 /obj/machinery/computer/cargo/emag_act(mob/user)
 	if(emagged)
@@ -33,7 +39,7 @@
 	emagged = TRUE
 	contraband = TRUE
 
-	// This also permamently sets this on the circuit board
+	// This also permamently sets this on the circuit board to preserve the values when the console is deconstructed.
 	var/obj/item/circuitboard/computer/cargo/board = circuit
 	board.contraband = TRUE
 	board.emagged = TRUE


### PR DESCRIPTION
Reassembling a supply console no longer resets the emagged/contraband values back to 0. 

This accounts for the supply console being unique in that its circuit board can be taken out and hacked/emagged while out of the computer frame.

Fixes #740

:cl: rd
fix: Supply console circuit boards preserve their contraband/emagged value on reassembly
/:cl: