### PR TITLE
Allow the light replacer to recycle objects directly off the floor

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -48,6 +48,8 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 		to_chat(user, "<span class='notice'>You attach wire to the [name].</span>")
 		var/obj/item/stack/light_w/new_tile = new(user.loc)
 		new_tile.add_fingerprint(user)
+	else if(istype(W, /obj/item/device/lightreplacer))
+		W.attackby(src, user)
 	else if(istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/V = W
 		if (V.get_amount() >= 1 && get_amount() >= 1)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -531,7 +531,7 @@
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
 /obj/item/storage/box/lights/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/device/lightreplacer))
+	if(issilicon(user) && istype(I, /obj/item/device/lightreplacer))
 		I.attackby(src, user)
 	else
 		..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -530,6 +530,13 @@
 	max_combined_w_class = 21
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
+/obj/item/storage/box/lights/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/device/lightreplacer))
+		I.attackby(src, user)
+	else
+		..()
+	return
+
 /obj/item/storage/box/lights/bulbs/PopulateContents()
 	for(var/i in 1 to 21)
 		new /obj/item/light/bulb(src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -750,6 +750,8 @@
 			rigged = 1
 
 		S.reagents.clear_reagents()
+	else if(istype(I, /obj/item/device/lightreplacer))
+		I.attackby(src, user)
 	else
 		..()
 	return


### PR DESCRIPTION
This PR allows engineer borgs (and players) to feed glass/lightbulbs into their light replacer directly off the floor.

This was already working fine for `/obj/item/shard`, so I copied the code from `/obj/item/shard/attackby` to the other types of objects that can be fed into a light replacer.

Closes #1039 

:cl: rd
fix: Light replacers can now be fed materials directly off the floor. 
/:cl: