### PR TITLE
Tweaks to job playtime reqs

### DIFF
--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -13,7 +13,7 @@ Blueshield
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are a bodyguard for heads of staff. You are not a security officer. Do not do security's job."
 

--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -13,7 +13,7 @@ Blueshield
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 600 //10 hours
+	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are a bodyguard for heads of staff. You are not a security officer. Do not do security's job."
 

--- a/code/modules/jobs/job_types/blueshield.dm
+++ b/code/modules/jobs/job_types/blueshield.dm
@@ -13,7 +13,7 @@ Blueshield
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 600
+	exp_requirements = 1200
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are a bodyguard for heads of staff. You are not a security officer. Do not do security's job."
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -13,7 +13,7 @@ Captain
 	selection_color = "#ccccff"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 420
+	exp_requirements = 1200
 	exp_type = EXP_TYPE_COMMAND
 	special_notice = "You may be the Captain of this station, but you are still beholden to The Corporation."
 
@@ -68,7 +68,7 @@ Head of Personnel
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 15
-	exp_requirements = 360
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
 	special_notice = "You are not a security officer. Do not do their job."

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -13,7 +13,7 @@ Captain
 	selection_color = "#ccccff"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 180
+	exp_requirements = 420
 	exp_type = EXP_TYPE_COMMAND
 	special_notice = "You may be the Captain of this station, but you are still beholden to The Corporation."
 
@@ -68,7 +68,7 @@ Head of Personnel
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 15
-	exp_requirements = 180
+	exp_requirements = 360
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
 	special_notice = "You are not a security officer. Do not do their job."

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -9,6 +9,7 @@ Quartermaster
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
+	exp_requirements = 120
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
 	outfit = /datum/outfit/job/quartermaster

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -14,7 +14,7 @@ Chief Engineer
 	selection_color = "#ffeeaa"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 180
+	exp_requirements = 360
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
 	wiki_page = "Engineering_SOP"
@@ -75,7 +75,7 @@ Station Engineer
 	spawn_positions = 5
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
-	exp_requirements = 60
+	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
 	wiki_page = "Station_Engineer"
 
@@ -133,7 +133,7 @@ Atmospheric Technician
 	spawn_positions = 2
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
-	exp_requirements = 60
+	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
 	wiki_page = "Atmospheric_Technician"
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -14,7 +14,7 @@ Chief Engineer
 	selection_color = "#ffeeaa"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 360
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
 	wiki_page = "Engineering_SOP"

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -14,7 +14,7 @@ Chief Medical Officer
 	selection_color = "#ffddf0"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 360
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
 	wiki_page = "Medical_SOP"

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -14,7 +14,7 @@ Chief Medical Officer
 	selection_color = "#ffddf0"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 180
+	exp_requirements = 360
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
 	wiki_page = "Medical_SOP"
@@ -98,7 +98,7 @@ Chemist
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
-	exp_requirements = 60
+	exp_requirements = 120
 	wiki_page = "Guide_to_chemistry"
 
 	outfit = /datum/outfit/job/chemist
@@ -175,7 +175,7 @@ Virologist
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
-	exp_requirements = 60
+	exp_requirements = 120
 	wiki_page = "Infections"
 
 	outfit = /datum/outfit/job/virologist

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -15,7 +15,7 @@ Research Director
 	req_admin_notify = 1
 	minimal_player_age = 7
 	exp_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 360
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 	wiki_page = "Science_SOP"
 

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -15,7 +15,7 @@ Research Director
 	req_admin_notify = 1
 	minimal_player_age = 7
 	exp_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 180
+	exp_requirements = 360
 	exp_type = EXP_TYPE_CREW
 	wiki_page = "Science_SOP"
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -20,7 +20,7 @@ Head of Security
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 600
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 	special_notice = "Space Law is THE LAW. Not a suggestion."

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -20,7 +20,7 @@ Head of Security
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 	special_notice = "Space Law is THE LAW. Not a suggestion."
@@ -304,7 +304,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
 	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance. You are to tend to the medical needs of officers and prisoners."
 

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -12,7 +12,7 @@ AI
 	supervisors = "your laws"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 600
+	exp_requirements = 900
 	exp_type = EXP_TYPE_CREW
 
 /datum/job/ai/equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -12,7 +12,7 @@ AI
 	supervisors = "your laws"
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 180
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
@@ -44,7 +44,7 @@ Cyborg
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
-	exp_requirements = 120
+	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)


### PR DESCRIPTION
:cl: Flatty
tweak: Numerous jobs got their playtime requirements changed. Won't concern anyone with more than ten hours spent on the server.
/:cl:

| Job | Before [h] | Now [h] |
| ------------- | ------------- | ------------- |
| Cap | 3 | 7 |
| HoP | 3 | 6 |
| CMO | 3 | 6 |
| RD | 3 | 6 |
| HoS | 5 | 10 |
| CE | 3 | 6 |
| AI | 3 | 10 |
| Borgo | 2 | 3 |
| QM | 0 | 2 |
| Engineer | 1 | 2 |
| Atmos Tech | 1 | 2 |
| Chemist | 1 | 2 |
| Viro | 1 | 2 |
| **decreased** | **that** | **one⇩⇩⇩** |
| Brig Phys | 5 | 3 |

Because recently I've seen a hilariously high amount of completely new players in roles which most definitely are not appropriate to their skill level. Discuss.


