### PR TITLE
Kills skateboard and scooter recipes

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,7 +1,6 @@
 GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 25, one_per_turf = 0), \
 	))
 
 /obj/item/stack/rods

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -326,22 +326,6 @@
 	reqs = list(/obj/item/stack/sheet/animalhide/unathi = 1)
 	category = CAT_MISC
 
-/datum/crafting_recipe/skateboard
-	name = "Skateboard"
-	result = /obj/vehicle/scooter/skateboard
-	time = 60
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/rods = 10)
-	category = CAT_MISC
-
-/datum/crafting_recipe/scooter
-	name = "Scooter"
-	result = /obj/vehicle/scooter
-	time = 65
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/rods = 12)
-	category = CAT_MISC
-
 /datum/crafting_recipe/papersack
 	name = "Paper Sack"
 	result = /obj/item/storage/box/papersack


### PR DESCRIPTION
:cl: Flatty
del: You can no longer craft scooters and skateboards in the crafting menu
/:cl:

Because the new meta is using these at all times, apparently. They make you unslippable and fast at the cost of 10 metal. Looking like a shitty meme included.

You can still find the vehicles in different places all over the world.