### PR TITLE
Wallet icon_state fallback

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -59,7 +59,10 @@
 /obj/item/storage/wallet/update_icon()
 	icon_state = "wallet"
 	if(front_id)
-		icon_state = "wallet_[front_id.icon_state]"
+		if ("wallet_[front_id.icon_state]" in icon_states(src.icon))
+			icon_state = "wallet_[front_id.icon_state]"
+		else
+			icon_state = "wallet_id"
 
 
 


### PR DESCRIPTION
Prevents wallets from disappearing if there is no sprite matching the icon_state of ID inserted.

Fixes #837 #1003 

We might want to open a separate issue for creating wallet sprites matching the new ID sprites.

:cl: rd
fix: Wallets no longer disappear when IDs are inserted into them
/:cl:
