### PR TITLE
Limit channels of independent radio transmissions

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -107,7 +107,7 @@
 	else if(data == 5)
 
 		for(var/obj/item/device/radio/R in GLOB.all_radios["[freq]"])
-			if(!R.independent)
+			if(!(freq in R.independent))
 				continue
 
 			if(R.receive_range(freq, level) > -1)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -7,7 +7,7 @@
 	origin_tech = "engineering=2;bluespace=1"
 	var/translate_binary = 0
 	var/syndie = 0
-	var/independent = FALSE
+	var/independent = list()
 	var/list/channels = list()
 
 /obj/item/device/encryptionkey/syndicate
@@ -137,7 +137,7 @@
 	name = "centcom radio encryption key"
 	desc = "An encryption key for a radio headset.  To access the centcom channel, use :y."
 	icon_state = "cent_cypherkey"
-	independent = TRUE
+	independent = list("CentCom")
 	channels = list("CentCom" = 1)
 
 /obj/item/device/encryptionkey/ai //ported from NT, this goes 'inside' the AI.

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -295,8 +295,10 @@
 		if(keyslot2.syndie)
 			src.syndie = 1
 
-		if (keyslot2.independent)
-			independent = TRUE
+		for(var/ch_name in keyslot2.independent)
+			if (ch_name in src.independent)
+				continue
+			independent += GLOB.radiochannels[ch_name]
 
 
 	for(var/ch_name in channels)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -23,7 +23,7 @@
 	var/subspace_switchable = 0
 	var/subspace_transmission = 0
 	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
-	var/independent = FALSE // If true, bypasses any tcomms machinery.
+	var/independent = list() // list of channels that bypass any tcomms machinery.
 	var/freqlock = 0 //Frequency lock to stop the user from untuning specialist radios.
 	var/emped = 0	//Highjacked to track the number of consecutive EMPs on the radio, allowing consecutive EMP's to stack properly.
 //			"Example" = FREQ_LISTENING|FREQ_BROADCASTING
@@ -49,7 +49,7 @@
 	channels = list()
 	translate_binary = 0
 	syndie = 0
-	independent = FALSE
+	independent = list()
 
 	if(keyslot)
 		for(var/ch_name in keyslot.channels)
@@ -64,8 +64,10 @@
 		if(keyslot.syndie)
 			syndie = 1
 
-		if(keyslot.independent)
-			independent = TRUE
+		for(var/ch_name in keyslot.independent)
+			if (ch_name in src.independent)
+				continue
+			independent += GLOB.radiochannels[ch_name]
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
@@ -299,7 +301,7 @@
 
 	/* ###### `independent` radios bypass all comms relays. ###### */
 
-	if(independent)
+	if(freqnum in independent)
 		var/datum/signal/signal = new
 		signal.transmission_method = 2
 		signal.data = list(
@@ -477,9 +479,6 @@
 			return -1
 	if(freq == GLOB.SYND_FREQ)
 		if(!(src.syndie)) //Checks to see if it's allowed on that frequency, based on the encryption keys
-			return -1
-	if(freq == GLOB.CENTCOM_FREQ)
-		if(!independent)
 			return -1
 	if (!on)
 		return -1

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -511,7 +511,7 @@
 	var/obj/item/device/radio/R = H.ears
 	R.set_frequency(GLOB.REDTEAM_FREQ)
 	R.freqlock = TRUE
-	R.independent = TRUE
+	R.independent = list(GLOB.REDTEAM_FREQ)
 	H.dna.species.stunmod = 0
 
 /datum/outfit/ctf/blue/post_equip(mob/living/carbon/human/H)
@@ -519,7 +519,7 @@
 	var/obj/item/device/radio/R = H.ears
 	R.set_frequency(GLOB.BLUETEAM_FREQ)
 	R.freqlock = TRUE
-	R.independent = TRUE
+	R.independent = list(GLOB.BLUETEAM_FREQ)
 	H.dna.species.stunmod = 0
 
 


### PR DESCRIPTION
"Independent" (ERT and CTF) radios no longer use tcomms-independent broadcasts for all channels. They're now limited to frequencies defined by their radio encryption keys.

Fixes #993

:cl: rd
fix: ERT members can now communicate with the station crew using their CentComm-issued radio headsets
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
