### PR TITLE
Removes baseball bat recipe

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -175,7 +175,6 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10),\
 	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 4, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
 	new/datum/stack_recipe("wooden crate", /obj/structure/closet/crate/wooden, 6, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
-	new/datum/stack_recipe("baseball bat", /obj/item/melee/baseball_bat, 5, time = 15),\
 	))
 
 /obj/item/stack/sheet/mineral/wood


### PR DESCRIPTION
Removes the baseball recipe from the wooden stack.
:cl: 
del: Removes baseball bat recipe from wooden stack.
/:cl:

In my opinion, the bats are only used to greytide, and isn't usually used by antags (since they already have tools at their disposal, usually) and if there is a ton of bats around the station, usually expect someone beating up someone else for no good reason.

**Tested**
