### PR TITLE
Lockboxes are harder to break

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -9,6 +9,8 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
 	storage_slots = 4
+	max_integrity = 1500
+	obj_integrity = 1500
 	req_access = list(ACCESS_ARMORY)
 	var/locked = TRUE
 	var/broken = FALSE


### PR DESCRIPTION
They're there for a reason. 20 shots from a mining tool shouldn't be enough to circumvent them.

:cl: Flatty
tweak: Lockboxes are way harder to break.
/:cl: