### PR TITLE
Dwarves can no longer pick up dwarves that can no longer pick up dwarves that...

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -86,6 +86,9 @@
 	if(src == user)
 		to_chat(user, "<span class='warning'>You can't pick yourself up.</span>")
 		return FALSE
+	if(user.can_be_held)
+		to_chat(user, "<span class='warning'>You're too small to pick that up.</span>")
+		return FALSE
 	visible_message("<span class='warning'>[user] starts picking up [src].</span>", \
 					"<span class='userdanger'>[user] starts picking you up!</span>")
 	if(!do_after(user, 20, target = src))


### PR DESCRIPTION
:cl: 
tweak: Mobs that can_be_held can no longer pick up other mobs that can_be_held
/:cl:

[why]: as a dwarf, I had a dwarf in my backpack successfully pick me up.

https://www.youtube.com/watch?v=G2jUhnCU9iA

Fixes https://github.com/OracleStation/OracleStation/issues/1132