### PR TITLE
 Round weighting now reduces the chances of repeating a recently played mode

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -10,6 +10,8 @@ SUBSYSTEM_DEF(persistence)
 	var/list/obj/structure/chisel_message/chisel_messages = list()
 	var/list/saved_messages = list()
 
+	var/list/saved_modes = list(1,2,3)
+
 	var/savefile/trophy_sav
 	var/list/saved_trophies = list()
 
@@ -18,6 +20,7 @@ SUBSYSTEM_DEF(persistence)
 	LoadPoly()
 	LoadChiselMessages()
 	LoadTrophies()
+	LoadRecentModes()
 	..()
 
 /datum/controller/subsystem/persistence/proc/LoadSatchels()
@@ -125,6 +128,16 @@ SUBSYSTEM_DEF(persistence)
 
 	SetUpTrophies(saved_trophies.Copy())
 
+/datum/controller/subsystem/persistence/proc/LoadRecentModes()
+	var/json_file = file("data/RecentModes.json")
+	if(!fexists(json_file))
+		return
+	var/list/json = list()
+	json = json_decode(file2text(json_file))
+	if(!json)
+		return
+	saved_modes = json["data"]
+
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)
 	for(var/A in GLOB.trophy_cases)
 		var/obj/structure/displaycase/trophy/T = A
@@ -154,6 +167,7 @@ SUBSYSTEM_DEF(persistence)
 	CollectChiselMessages()
 	CollectSecretSatchels()
 	CollectTrophies()
+	CollectRoundtype()
 
 /datum/controller/subsystem/persistence/proc/CollectSecretSatchels()
 	for(var/A in new_secret_satchels)
@@ -197,3 +211,13 @@ SUBSYSTEM_DEF(persistence)
 		data["message"] = T.trophy_message
 		data["placer_key"] = T.placer_key
 		saved_trophies += list(data)
+
+/datum/controller/subsystem/persistence/proc/CollectRoundtype()
+	saved_modes[3] = saved_modes[2]
+	saved_modes[2] = saved_modes[1]
+	saved_modes[1] = SSticker.mode.config_tag
+	var/json_file = file("data/RecentModes.json")
+	var/list/file_data = list()
+	file_data["data"] = saved_modes
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(file_data))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -104,6 +104,9 @@ PROBABILITY DEVIL_AGENTS 0
 ## You probably want to keep sandbox off by default for secret and random.
 PROBABILITY SANDBOX 0
 
+## Percent weight reductions for three of the most recent modes
+
+REPEATED_MODE_ADJUST 45 35 15
 
 ## Toggles for continuous modes.
 ## Modes that aren't continuous will end the instant all antagonists are dead.


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/30522


:cl: steamp0rt:
tweak: 10 traitorling rounds in a row are less likely now!
/:cl:
