### PR TITLE
swarmers can't eat field generators

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -278,10 +278,6 @@
 	S.DisIntegrate(src)
 	return TRUE
 
-/obj/machinery/field/generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	S.DisIntegrate(src)
-	return TRUE
-
 /obj/machinery/gravity_generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	S.DisIntegrate(src)
 	return TRUE
@@ -319,6 +315,10 @@
 	return FALSE
 
 /obj/structure/cable/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
+	return FALSE
+
+/obj/machinery/field/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
 	return FALSE
 


### PR DESCRIPTION
:cl: Flatty
tweak: Swarmers can't eat field generators, because that is bad
/:cl:

Generally they're not meant to be this destructive, this seems to have been an oversight of some coder who got high off the wrong drugs.