### PR TITLE
Disease outbreaks now have a chance of generating a random advanced virus

### DIFF
--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -57,3 +57,26 @@
 		name = "Experimental Insomnia Cure"
 		symptoms = list(new/datum/symptom/narcolepsy)
 	..(process, D, copy)
+
+//Randomly generated Disease, for virus crates and events
+/datum/disease/advance/random
+	name = "Experimental Disease"
+
+/datum/disease/advance/random/New(max_symptoms, max_level = 8)
+	if(!max_symptoms)
+		max_symptoms = rand(1, 6)
+	var/list/datum/symptom/possible_symptoms = list()
+	for(var/symptom in subtypesof(/datum/symptom))
+		var/datum/symptom/S = symptom
+		if(initial(S.level) > max_level)
+			continue
+		if(initial(S.level) <= 0) //unobtainable symptoms
+			continue
+		possible_symptoms += S
+	for(var/i in 1 to max_symptoms)
+		var/datum/symptom/chosen_symptom = pick_n_take(possible_symptoms)
+		if(chosen_symptom)
+			var/datum/symptom/S = new chosen_symptom
+			symptoms += S
+	Refresh()
+	name = "Sample #[rand(1,10000)]"

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -7,9 +7,7 @@
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15
-
 	var/virus_type
-
 	var/max_severity = 3
 
 
@@ -22,7 +20,7 @@
 
 /datum/round_event/disease_outbreak/start()
 	var/advanced_virus = FALSE
-	max_severity = 3 + max(Floor((world.time - control.earliest_start)/6000),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	max_severity = 3 + max(Floor((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
 	if(prob(20 + (10 * max_severity)))
 		advanced_virus = TRUE
 
@@ -61,16 +59,19 @@
 			else
 				D = new virus_type()
 		else
-			D = make_virus(max_severity, max_severity)
+			D = new /datum/disease/advance/random(max_severity, max_severity)
+		if(!H.CanContractDisease(D))
+			QDEL_NULL(D)
+			continue
 		D.carrier = TRUE
-		H.AddDisease(D)
+		H.ForceContractDisease(D, FALSE, TRUE)
 
 		if(advanced_virus)
 			var/datum/disease/advance/A = D
 			var/list/name_symptoms = list() //for feedback
 			for(var/datum/symptom/S in A.symptoms)
 				name_symptoms += S.name
-			message_admins("An event has triggered a random advanced virus outbreak on [key_name_admin(H)]! It has these symptoms: [english_list(name_symptoms)]")
+			message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(H)]! It has these symptoms: [english_list(name_symptoms)]")
 			log_game("An event has triggered a random advanced virus outbreak on [key_name(H)]! It has these symptoms: [english_list(name_symptoms)]")
 		break
 


### PR DESCRIPTION
port of https://github.com/tgstation/tgstation/pull/30307

:cl: steamp0rt, XDTM
fix: IPCs should no longer get infected by a virus from a random disease event 
tweak: The Disease Outbreak event now can generate random advanced viruses, with more symptoms and higher level as round time goes on.
/:cl:
