### PR TITLE
Gives the Mime the same clumsy mutation as the clown

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -180,8 +180,8 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 
 	if (changeling.current.mind)
 		var/mob/living/carbon/human/H = changeling.current
-		if(H.mind.assigned_role == "Clown")
-			to_chat(H, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
+		if(H.mind.assigned_role == "Clown" || H.mind.assigned_role == "Mime")
+			to_chat(H, "You have evolved beyond your clumsy nature, allowing you to wield weapons without harming yourself.")
 			H.dna.remove_mutation(CLOWNMUT)
 
 	var/obj_count = 1

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -122,8 +122,8 @@
 	if(!istype(mob))
 		return
 	if (mob.mind)
-		if (mob.mind.assigned_role == "Clown")
-			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+		if (mob.mind.assigned_role == "Clown" || mob.mind.assigned_role == "Mime")
+			to_chat(mob, "Your training has allowed you to overcome your clumsy nature, allowing you to wield weapons without harming yourself.")
 			mob.dna.remove_mutation(CLOWNMUT)
 
 	if(tome)

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -112,8 +112,8 @@ GLOBAL_LIST_INIT(gang_outfit_pool, list(/obj/item/clothing/suit/jacket/leather, 
 		return
 
 	if (mob.mind)
-		if (mob.mind.assigned_role == "Clown")
-			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+		if (mob.mind.assigned_role == "Clown" || mob.mind.assigned_role == "Mime")
+			to_chat(mob, "Your training has allowed you to overcome your clumsy nature, allowing you to wield weapons without harming yourself.")
 			mob.dna.remove_mutation(CLOWNMUT)
 
 	var/obj/item/device/gangtool/gangtool = new(mob)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -147,8 +147,8 @@
 		return
 
 	if (mob.mind)
-		if (mob.mind.assigned_role == "Clown")
-			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+		if (mob.mind.assigned_role == "Clown" || mob.mind.assigned_role == "Mime")
+			to_chat(mob, "Your training has allowed you to overcome your clumsy nature, allowing you to wield weapons without harming yourself.")
 			mob.dna.remove_mutation(CLOWNMUT)
 
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -114,6 +114,8 @@ Mime
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
 		H.mind.miming = 1
 
+	H.dna.add_mutation(CLOWNMUT)
+	H.dna.add_mutation(WACKY)
 /*
 Curator
 */

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -115,7 +115,6 @@ Mime
 		H.mind.miming = 1
 
 	H.dna.add_mutation(CLOWNMUT)
-	H.dna.add_mutation(WACKY)
 /*
 Curator
 */


### PR DESCRIPTION
:cl: 
tweak: Mime now starts with the same mutations as the Clown.
/:cl:

My reasoning is this: The mime should at least be humorous/entertaining to the crew. Also, to discourage the ever so present mindset of almost all Mimes we get to greytide and be shitters.

The antag stuff was adjusted to taken in account the Mimes getting the mutations, as in its removed as they do currently with the Clown, but I wasn't able to find the part for traitor for the mutation removal.
