### PR TITLE
Meson Fixes

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -231,7 +231,8 @@
 	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
 		var/lum = T.luminosity
 		T.luminosity = 6 // This is the maximum luminosity
-		processing_list = viewers(R, T)
+		for(var/mob/M in view(R, T))
+			processing_list += M
 		for(var/obj/O in view(R, T))
 			processing_list += O
 		T.luminosity = lum

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -35,7 +35,7 @@
 	else
 		vision_flags = SEE_TURFS
 		darkness_view = 1
-		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 		if(voluntary)
 			to_chat(user, "<span class='notice'>You toggle the goggles' scanning mode to \[Meson].</span>")
 		else


### PR DESCRIPTION
Ports tgstation/tgstation#36504 and tgstation/tgstation#33005

:cl: ShizCalev
fix: Engineering Scanner Goggles now properly display lighting in Meson mode.
/:cl:

:cl: AnturK
fix: Meson Goggles no longer let you hear people through walls.
/:cl: