### PR TITLE
Fixes erroneous pipe_state for heat exchange junctions.

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -15,7 +15,7 @@
 	device_type = BINARY
 
 	construction_type = /obj/item/pipe/directional
-	pipe_state = "junction2"
+	pipe_state = "junction"
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/SetInitDirections()
 	switch(dir)


### PR DESCRIPTION
This was a one character change why did I never fix this?

![image](https://user-images.githubusercontent.com/202160/44704415-1ab84b00-aa93-11e8-94d0-793014aaaade.png)

Fixes #1175 
Fixes #756

:cl: AndrewMontagne
fix: Heat exchange junction items now have a sprite again
/:cl:
