### PR TITLE
Minebots no longer have genders

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/mob/aibots.dmi'
 	icon_state = "mining_drone"
 	icon_living = "mining_drone"
+	gender = NEUTER
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPUSH
 	mouse_opacity = MOUSE_OPACITY_ICON
 	faction = list("neutral")


### PR DESCRIPTION
Minebots are now forced neutral gender so they should no longer display as he/her

fixes #1192 

:cl:
fix: fixed NT minebots having genders
/:cl:

[why]: This serves as a first PR sort of thing, mostly just to see if git doesn't shit itself and to actually fix an issue. It's a 13 character fix but I have another fix in the works right now which should be up soon granted I don't fuck it up royally.