### PR TITLE
Gets rid of stealth pickups

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -165,11 +165,7 @@
 
 /mob/proc/put_in_hand(obj/item/I, hand_index)
 	if(can_put_in_hand(I, hand_index))
-		if(m_intent == MOVE_INTENT_WALK)
-			to_chat(src, "<span class='notice'>You start [pick("inconspicuously", "slowly", "carefully", "silently")] picking up [I]. (Walk mode)</span>")
-			if(!do_after(src, 2 SECONDS, target = I))
-				return FALSE
-		else if(isturf(I.loc))
+		if(isturf(I.loc))
 			I.do_pickup_animation(src)
 		I.forceMove(src)
 		held_items[hand_index] = I


### PR DESCRIPTION
>tries to remove e-dagger/sleepy pen from PDA with alt click
>takes two seconds to remove it

>try to get literally any item in the middle of a water vapor-wettened floor
>lolno

:cl: steamp0rt
del: No more stealth pickups. Not like they were used intentionally anyways.
/:cl:

